### PR TITLE
Feat/5 meeting create api

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
@@ -9,7 +9,7 @@ import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
 
 public record CreateMeetingCommand(
         UUID hostId, // 모임장 ID
-        UUID bookId, // 책 ID
+        String bookId, // 책 ID
         String title, // 모임명
         String description, // 모임 설명
         MeetingType meetingType, // 모임 유형

--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
@@ -1,0 +1,25 @@
+package com.pagely.meetingservice.meeting.application.dto.command;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingType;
+import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
+import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
+
+public record CreateMeetingCommand(
+        UUID hostId, // 모임장 ID
+        UUID bookId, // 책 ID
+        String title, // 모임명
+        String description, // 모임 설명
+        MeetingType meetingType, // 모임 유형
+        LocalDateTime recruitStartAt, // 모임 시작
+        LocalDateTime recruitEndAt, // 모임 종료
+        Integer recruitMax, // 모집 정원
+        ReadingLevel readingLevel, // 독서 난이도
+        String ruleMemo, // 규칙 메모
+        RecruitRate recruitRate, // 모집 주기
+        Boolean freePaid, // 무료/유료 여부
+        UUID createdBy
+    ) {
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingResult.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingResult.java
@@ -1,0 +1,54 @@
+package com.pagely.meetingservice.meeting.application.dto.result;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.model.MeetingStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingType;
+import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
+import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
+import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
+
+public record MeetingResult(
+    UUID id,
+    UUID hostId,
+    UUID bookId,
+    String title,
+    String description,
+    MeetingType meetingType,
+    MeetingStatus meetingStatus,
+    RecruitStatus recruitStatus,
+    LocalDateTime recruitStartAt,
+    LocalDateTime recruitEndAt,
+    Integer recruitMax,
+    ReadingLevel readingLevel,
+    String ruleMemo,
+    RecruitRate recruitRate,
+    Boolean freePaid,
+    LocalDateTime createdAt,
+    UUID createdBy
+) {
+    public static MeetingResult from(Meeting m){
+        return new MeetingResult(
+            m.getId(),
+            m.getHostId(),
+            m.getBookId(),
+            m.getTitle(),
+            m.getDescription(),
+            m.getMeetingType(),
+            m.getMeetingStatus(),
+            m.getRecruitStatus(),
+            m.getRecruitStartAt(),
+            m.getRecruitEndAt(),
+            m.getRecruitMax(),
+            m.getReadingLevel(),
+            m.getRuleMemo(),
+            m.getRecruitRate(),
+            m.isFreePaid(),
+            m.getCreatedAt(),
+            m.getCreatedBy()
+        );
+    }
+    
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingResult.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingResult.java
@@ -1,54 +1,53 @@
 package com.pagely.meetingservice.meeting.application.dto.result;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import com.pagely.meetingservice.meeting.domain.model.MeetingStatus;
 import com.pagely.meetingservice.meeting.domain.model.MeetingType;
 import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
 import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
 import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record MeetingResult(
-    UUID id,
-    UUID hostId,
-    String bookId,
-    String title,
-    String description,
-    MeetingType meetingType,
-    MeetingStatus meetingStatus,
-    RecruitStatus recruitStatus,
-    LocalDateTime recruitStartAt,
-    LocalDateTime recruitEndAt,
-    Integer recruitMax,
-    ReadingLevel readingLevel,
-    String ruleMemo,
-    RecruitRate recruitRate,
-    Boolean freePaid,
-    LocalDateTime createdAt,
-    UUID createdBy
+        UUID id,
+        UUID hostId,
+        String bookId,
+        String title,
+        String description,
+        MeetingType meetingType,
+        MeetingStatus meetingStatus,
+        RecruitStatus recruitStatus,
+        LocalDateTime recruitStartAt,
+        LocalDateTime recruitEndAt,
+        Integer recruitMax,
+        ReadingLevel readingLevel,
+        String ruleMemo,
+        RecruitRate recruitRate,
+        Boolean freePaid,
+        LocalDateTime createdAt,
+        UUID createdBy
 ) {
-    public static MeetingResult from(Meeting m){
+    public static MeetingResult from(Meeting m) {
         return new MeetingResult(
-            m.getId(),
-            m.getHostId(),
-            m.getBookId(),
-            m.getTitle(),
-            m.getDescription(),
-            m.getMeetingType(),
-            m.getMeetingStatus(),
-            m.getRecruitStatus(),
-            m.getRecruitStartAt(),
-            m.getRecruitEndAt(),
-            m.getRecruitMax(),
-            m.getReadingLevel(),
-            m.getRuleMemo(),
-            m.getRecruitRate(),
-            m.isFreePaid(),
-            m.getCreatedAt(),
-            m.getCreatedBy()
+                m.getId(),
+                m.getHostId(),
+                m.getBookId(),
+                m.getTitle(),
+                m.getDescription(),
+                m.getMeetingType(),
+                m.getMeetingStatus(),
+                m.getRecruitStatus(),
+                m.getRecruitStartAt(),
+                m.getRecruitEndAt(),
+                m.getRecruitMax(),
+                m.getReadingLevel(),
+                m.getRuleMemo(),
+                m.getRecruitRate(),
+                m.isFreePaid(),
+                m.getCreatedAt(),
+                m.getCreatedBy()
         );
     }
-    
+
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingResult.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingResult.java
@@ -13,7 +13,7 @@ import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
 public record MeetingResult(
     UUID id,
     UUID hostId,
-    UUID bookId,
+    String bookId,
     String title,
     String description,
     MeetingType meetingType,

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingApplicationService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingApplicationService.java
@@ -44,7 +44,7 @@ public class MeetingApplicationService {
             command.createdBy()
         );
         Meeting saved = meetingRepository.save(meeting);
-        return MeetingResult.from(meeting);
+        return MeetingResult.from(saved);
     }
     
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingApplicationService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingApplicationService.java
@@ -1,0 +1,50 @@
+package com.pagely.meetingservice.meeting.application.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingCommand;
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingResult;
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
+
+
+@Service
+@Transactional(readOnly = true)
+public class MeetingApplicationService {
+
+    private final MeetingRepository meetingRepository;
+
+    public MeetingApplicationService(MeetingRepository meetingRepository) {
+        this.meetingRepository = meetingRepository;
+    }
+
+    @Transactional
+    public MeetingResult createMeeting(CreateMeetingCommand command) {
+        UUID meetingId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        Meeting meeting = Meeting.create(
+            meetingId,
+            command.hostId(),
+            command.bookId(),
+            command.title(),
+            command.description(),
+            command.meetingType(),
+            command.recruitStartAt(),
+            command.recruitEndAt(),
+            command.recruitMax(),
+            command.readingLevel(),
+            command.ruleMemo(),
+            command.recruitRate(),
+            command.freePaid(),
+            now,
+            command.createdBy()
+        );
+        Meeting saved = meetingRepository.save(meeting);
+        return MeetingResult.from(meeting);
+    }
+    
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -118,7 +118,7 @@ public class Meeting {
     public static Meeting create(
             UUID id,
             UUID hostId,
-            UUID bookId,
+            String bookId,
             String title,
             String description,
             MeetingType meetingType,
@@ -163,7 +163,7 @@ public class Meeting {
         return hostId;
     }
 
-    public UUID getBookId() {
+    public String getBookId() {
         return bookId;
     }
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -99,18 +99,127 @@ public class Meeting {
     protected Meeting() {
     }
 
-//    // 소프트 삭제 여부 확인
-//    public boolean isDeleted() {
-//        return deletedAt != null;
-//    }
-//
-//    // 모집 가능 여부 확인
-//    public boolean isRecruiting() {
-//        return recruitStatus == RecruitStatus.RECRUITING;
-//    }
-//
-//    // 모임장 여부 확인
-//    public boolean isHost(UUID userId) {
-//        return hostId.equals(userId);
-//    }
+    // // 소프트 삭제 여부 확인
+    // public boolean isDeleted() {
+    // return deletedAt != null;
+    // }
+    //
+    // // 모집 가능 여부 확인
+    // public boolean isRecruiting() {
+    // return recruitStatus == RecruitStatus.RECRUITING;
+    // }
+    //
+    // // 모임장 여부 확인
+    // public boolean isHost(UUID userId) {
+    // return hostId.equals(userId);
+    // }
+
+    // 신규 모임 생성 (문서: 생성 직후 UPCOMING / RECRUITING)
+    public static Meeting create(
+            UUID id,
+            UUID hostId,
+            UUID bookId,
+            String title,
+            String description,
+            MeetingType meetingType,
+            LocalDateTime recruitStartAt,
+            LocalDateTime recruitEndAt,
+            int recruitMax,
+            ReadingLevel readingLevel,
+            String ruleMemo,
+            RecruitRate recruitRate,
+            boolean freePaid,
+            LocalDateTime createdAt,
+            UUID createdBy) {
+        if (recruitStartAt.isAfter(recruitEndAt)) {
+            throw new IllegalArgumentException("모집 시작 시각은 종료 시각보다 늦을 수 없습니다.");
+        }
+        Meeting meeting = new Meeting();
+        meeting.id = id;
+        meeting.hostId = hostId;
+        meeting.bookId = bookId;
+        meeting.title = title;
+        meeting.description = description;
+        meeting.meetingType = meetingType;
+        meeting.meetingStatus = MeetingStatus.UPCOMING;
+        meeting.recruitStatus = RecruitStatus.RECRUITING;
+        meeting.recruitStartAt = recruitStartAt;
+        meeting.recruitEndAt = recruitEndAt;
+        meeting.recruitMax = recruitMax;
+        meeting.readingLevel = readingLevel;
+        meeting.ruleMemo = ruleMemo;
+        meeting.recruitRate = recruitRate;
+        meeting.freePaid = freePaid;
+        meeting.createdAt = createdAt;
+        meeting.createdBy = createdBy;
+        return meeting;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getHostId() {
+        return hostId;
+    }
+
+    public UUID getBookId() {
+        return bookId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public MeetingType getMeetingType() {
+        return meetingType;
+    }
+
+    public MeetingStatus getMeetingStatus() {
+        return meetingStatus;
+    }
+
+    public RecruitStatus getRecruitStatus() {
+        return recruitStatus;
+    }
+
+    public LocalDateTime getRecruitStartAt() {
+        return recruitStartAt;
+    }
+
+    public LocalDateTime getRecruitEndAt() {
+        return recruitEndAt;
+    }
+
+    public int getRecruitMax() {
+        return recruitMax;
+    }
+
+    public ReadingLevel getReadingLevel() {
+        return readingLevel;
+    }
+
+    public String getRuleMemo() {
+        return ruleMemo;
+    }
+
+    public RecruitRate getRecruitRate() {
+        return recruitRate;
+    }
+
+    public boolean isFreePaid() {
+        return freePaid;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public UUID getCreatedBy() {
+        return createdBy;
+    }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingRepository.java
@@ -1,0 +1,11 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaMeetingRepository extends JpaRepository<Meeting, UUID> {
+
+    List<Meeting> findByHostId(UUID hostId);
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingRepositoryAdapter.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MeetingRepositoryAdapter implements MeetingRepository {
+
+    private final JpaMeetingRepository jpaMeetingRepository;
+
+    public MeetingRepositoryAdapter(JpaMeetingRepository jpaMeetingRepository) {
+        this.jpaMeetingRepository = jpaMeetingRepository;
+    }
+
+    @Override
+    public Meeting save(Meeting meeting) {
+        return jpaMeetingRepository.save(meeting);
+    }
+
+    @Override
+    public Optional<Meeting> findById(UUID meetingId) {
+        return jpaMeetingRepository.findById(meetingId);
+    }
+
+    @Override
+    public List<Meeting> findAll() {  // 조회 페이징 API 구현 때 수정
+        return jpaMeetingRepository.findAll();
+    }
+
+    @Override
+    public List<Meeting> findByHostId(UUID hostId) {
+        return jpaMeetingRepository.findByHostId(hostId);
+    }
+
+    @Override
+    public boolean existsById(UUID meetingId) {
+        return jpaMeetingRepository.existsById(meetingId);
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/MeetingController.java
@@ -1,4 +1,0 @@
-package com.pagely.meetingservice.meeting.presentation;
-
-public class MeetingController {
-}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -1,0 +1,50 @@
+package com.pagely.meetingservice.meeting.presentation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingCommand;
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingResult;
+import com.pagely.meetingservice.meeting.application.service.MeetingApplicationService;
+import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingRequest;
+import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingResponse;
+
+import jakarta.validation.Valid;
+
+
+@RestController
+@RequestMapping("/api/v1/meetings")
+public class MeetingController {
+    private final MeetingApplicationService meetingApplicationService;
+
+    public MeetingController(MeetingApplicationService meetingApplicationService) {
+        this.meetingApplicationService = meetingApplicationService;
+    }
+
+    @PostMapping // 모임 생성 API
+    public ResponseEntity<MeetingResponse> createMeeting(@Valid @RequestBody CreateMeetingRequest req){
+        CreateMeetingCommand command = new CreateMeetingCommand(
+            req.hostId(),
+            req.bookId(),
+            req.title(),
+            req.description(),
+            req.meetingType(),
+            req.recruitStartAt(),
+            req.recruitEndAt(),
+            req.recruitMax(),
+            req.readingLevel(),
+            req.ruleMemo(),
+            req.recruitRate(),
+            req.freePaid(),
+            req.hostId() // createdBy 임시로 hostId 사용
+        );
+        MeetingResult result = meetingApplicationService.createMeeting(command);
+        MeetingResponse response = MeetingResponse.from(result);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response); // 201 응답 반환
+    }
+    
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
@@ -15,11 +15,11 @@ public record CreateMeetingRequest(
 
         @NotNull UUID hostId,
 
-        UUID bookId,
+        String bookId,
 
         @NotBlank @Size(max = 20) String title,
 
-        @Size(max = 500) String description,
+        String description,
 
         @NotNull MeetingType meetingType, // ONES, REGULAR
 

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
@@ -1,0 +1,39 @@
+package com.pagely.meetingservice.meeting.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingType;
+import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
+import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
+
+public record CreateMeetingRequest(
+
+        @NotNull UUID hostId,
+
+        UUID bookId,
+
+        @NotBlank @Size(max = 20) String title,
+
+        @Size(max = 500) String description,
+
+        @NotNull MeetingType meetingType, // ONES, REGULAR
+
+        @NotNull LocalDateTime recruitStartAt,
+
+        @NotNull LocalDateTime recruitEndAt,
+
+        @NotNull @Positive Integer recruitMax,
+
+        @NotNull ReadingLevel readingLevel, // BEGINNER, NORMAL, ADVANCED
+
+        String ruleMemo,
+
+        @NotNull RecruitRate recruitRate, // WEEKLY, BIWEEKLY, MONTHLY
+
+        @NotNull Boolean freePaid) {
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingResponse.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingResponse.java
@@ -1,0 +1,53 @@
+package com.pagely.meetingservice.meeting.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingResult;
+import com.pagely.meetingservice.meeting.domain.model.MeetingStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingType;
+import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
+import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
+import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
+
+public record MeetingResponse(
+    UUID id,
+    UUID hostId,
+    UUID bookId,
+    String title,
+    String description,
+    MeetingType meetingType,
+    MeetingStatus meetingStatus,
+    RecruitStatus recruitStatus,
+    LocalDateTime recruitStartAt,
+    LocalDateTime recruitEndAt,
+    Integer recruitMax,
+    ReadingLevel readingLevel,
+    String ruleMemo,
+    RecruitRate recruitRate,
+    Boolean freePaid,
+    LocalDateTime createdAt,
+    UUID createdBy
+) {
+    public static MeetingResponse from(MeetingResult r){
+        return new MeetingResponse(
+            r.id(),
+            r.hostId(),
+            r.bookId(),
+            r.title(),
+            r.description(),
+            r.meetingType(),
+            r.meetingStatus(),
+            r.recruitStatus(),
+            r.recruitStartAt(),
+            r.recruitEndAt(),
+            r.recruitMax(),
+            r.readingLevel(),
+            r.ruleMemo(),
+            r.recruitRate(),
+            r.freePaid(),
+            r.createdAt(),
+            r.createdBy()
+        );
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingResponse.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingResponse.java
@@ -13,7 +13,7 @@ import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
 public record MeetingResponse(
     UUID id,
     UUID hostId,
-    UUID bookId,
+    String bookId,
     String title,
     String description,
     MeetingType meetingType,


### PR DESCRIPTION
# 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- `POST /api/v1/meetings` 모임 생성 API 추가
- `CreateMeetingRequest` → `CreateMeetingCommand` → `MeetingApplicationService` → `MeetingResponse` 흐름으로 처리
- 도메인 `Meeting.create`에서 생성 직후 **`UPCOMING` / `RECRUITING`** 상태로 시작

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \ 
> Close #  \https://github.com/Pagely-wisely/meeting-service/issues/5
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # https://github.com/Pagely-wisely/meeting-service/issues/5

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회의 생성 API 추가: 호스트 ID, 도서 ID, 제목(최대 20자), 설명, 회의 유형, 모집 기간/최대 인원, 읽기 수준, 규칙 메모, 모집 비율, 유료/무료 여부 등을 지정해 회의를 생성할 수 있습니다.
  * POST /api/v1/meetings 엔드포인트가 추가되었으며, 생성 시 201 응답과 생성된 회의 상세(식별자·상태·모집기간·생성일 등)를 반환합니다.
* **버그 수정**
  * 모집 기간의 시간 유효성(시작 ≤ 종료) 검증이 서버에서 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->