### PR TITLE
Feat/17 모임 일정 생성 API 구현 및 PostgreSQL enum 매핑 적용

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingScheduleCommand.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingScheduleCommand.java
@@ -1,0 +1,18 @@
+package com.pagely.meetingservice.meeting.application.dto.command;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateMeetingScheduleCommand(
+
+        UUID meetingId,
+
+        String bookId,
+
+        LocalDateTime startAt,
+
+        String discussionNote,
+
+        UUID createdBy
+) {
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingScheduleResult.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingScheduleResult.java
@@ -1,0 +1,34 @@
+package com.pagely.meetingservice.meeting.application.dto.result;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MeetingScheduleResult(
+        UUID id,
+        UUID meetingId,
+        int scheduleNumber,
+        String bookId,
+        MeetingScheduleStatus status,
+        LocalDateTime startAt,
+        String discussionNote,
+        LocalDateTime createdAt,
+        UUID createdBy
+) {
+
+    // 엔티티를 응답용 Result로 변환
+    public static MeetingScheduleResult from(MeetingSchedule schedule) {
+        return new MeetingScheduleResult(
+                schedule.getId(),
+                schedule.getMeetingId(),
+                schedule.getScheduleNumber(),
+                schedule.getBookId(),
+                schedule.getStatus(),
+                schedule.getStartAt(),
+                schedule.getDiscussionNote(),
+                schedule.getCreatedAt(),
+                schedule.getCreatedBy()
+        );
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingQueryService.java
@@ -26,6 +26,7 @@ public class MeetingQueryService {
 
     // 모임 상세 조회
     public MeetingResult getMeeting(UUID meetingId) {
+        // TODO: 에러처리
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다"));
 

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleApplicationService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleApplicationService.java
@@ -1,0 +1,59 @@
+package com.pagely.meetingservice.meeting.application.service;
+
+import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingScheduleResult;
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingScheduleRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingScheduleApplicationService {
+
+    private final MeetingRepository meetingRepository;
+    private final MeetingScheduleRepository meetingScheduleRepository;
+
+    // 모임 일정 생성
+    @Transactional
+    public MeetingScheduleResult createSchedule(CreateMeetingScheduleCommand command) {
+        Meeting meeting = meetingRepository.findById(command.meetingId())
+                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+
+        // TODO: 인증 컨텍스트 연결 후 모임장 권한 검증
+        if (!meeting.getHostId().equals(command.createdBy())) {
+            throw new IllegalArgumentException("모임장만 일정을 생성할 수 있습니다.");
+        }
+
+        int nextScheduleNumber = calculateNextScheduleNumber(command.meetingId());
+
+        MeetingSchedule schedule = MeetingSchedule.create(
+                UUID.randomUUID(),
+                command.meetingId(),
+                nextScheduleNumber,
+                command.bookId(),
+                command.startAt(),
+                command.discussionNote(),
+                LocalDateTime.now(),
+                command.createdBy()
+        );
+
+        MeetingSchedule savedSchedule = meetingScheduleRepository.save(schedule);
+
+        return MeetingScheduleResult.from(savedSchedule);
+    }
+
+    // 다음 회차 번호 계산
+    private int calculateNextScheduleNumber(UUID meetingId) {
+        return meetingScheduleRepository.findByMeetingId(meetingId)
+                .stream()
+                .mapToInt(MeetingSchedule::getScheduleNumber)
+                .max()
+                .orElse(0) + 1;
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleApplicationService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleApplicationService.java
@@ -26,9 +26,9 @@ public class MeetingScheduleApplicationService {
                 .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
 
         // TODO: 인증 컨텍스트 연결 후 모임장 권한 검증
-        if (!meeting.getHostId().equals(command.createdBy())) {
-            throw new IllegalArgumentException("모임장만 일정을 생성할 수 있습니다.");
-        }
+//        if (!meeting.getHostId().equals(...) {
+//            throw new IllegalArgumentException("모임장만 일정을 생성할 수 있습니다.");
+//        }
 
         int nextScheduleNumber = calculateNextScheduleNumber(command.meetingId());
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -124,7 +124,12 @@ public class Meeting {
             LocalDateTime createdAt,
             UUID createdBy
     ) {
+        if (recruitMax <= 0) {
+            // TODO: 에러처리
+            throw new IllegalArgumentException("모집 인원은 1명 이상이어야 합니다.");
+        }
         if (recruitStartAt.isAfter(recruitEndAt)) {
+            // TODO: 에러처리
             throw new IllegalArgumentException("모집 시작 시각은 종료 시각보다 늦을 수 없습니다.");
         }
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Getter
 @Entity
@@ -36,17 +38,20 @@ public class Meeting {
 
     // 모임 유형
     @Enumerated(EnumType.STRING)
-    @Column(name = "meeting_type", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "meeting_type", nullable = false, columnDefinition = "meeting_type")
     private MeetingType meetingType;
 
     // 모임 상태
     @Enumerated(EnumType.STRING)
-    @Column(name = "meeting_status", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "meeting_status", nullable = false, columnDefinition = "meeting_status")
     private MeetingStatus meetingStatus;
 
     // 모집 상태
     @Enumerated(EnumType.STRING)
-    @Column(name = "recruit_status", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "recruit_status", nullable = false, columnDefinition = "recruit_status")
     private RecruitStatus recruitStatus;
 
     // 모집 시작 시각
@@ -63,7 +68,8 @@ public class Meeting {
 
     // 독서 난이도
     @Enumerated(EnumType.STRING)
-    @Column(name = "reading_level", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "reading_level", nullable = false, columnDefinition = "reading_level")
     private ReadingLevel readingLevel;
 
     // 모임 규칙 메모
@@ -72,7 +78,8 @@ public class Meeting {
 
     // 모임 주기
     @Enumerated(EnumType.STRING)
-    @Column(name = "recruit_rate", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "recruit_rate", nullable = false, columnDefinition = "recruit_rate")
     private RecruitRate recruitRate;
 
     // 무료/유료 여부

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingSchedule.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingSchedule.java
@@ -8,7 +8,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Getter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
+@Getter
 @Entity
 @Table(name = "p_meeting_schedules")
 public class MeetingSchedule {
@@ -30,7 +34,8 @@ public class MeetingSchedule {
 
     // 일정 상태
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "status", nullable = false, columnDefinition = "meeting_schedule_status")
     private MeetingScheduleStatus status;
 
     // 시작 시각
@@ -41,10 +46,11 @@ public class MeetingSchedule {
     @Column(name = "discussion_note")
     private String discussionNote;
 
-    // 공통 감사 컬럼
+    // 생성 시각
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    // 생성자 ID
     @Column(name = "created_by", nullable = false, updatable = false)
     private UUID createdBy;
 
@@ -61,5 +67,33 @@ public class MeetingSchedule {
     private UUID deletedBy;
 
     protected MeetingSchedule() {
+    }
+
+    // 신규 모임 일정 생성
+    public static MeetingSchedule create(
+            UUID id,
+            UUID meetingId,
+            int scheduleNumber,
+            String bookId,
+            LocalDateTime startAt,
+            String discussionNote,
+            LocalDateTime createdAt,
+            UUID createdBy
+    ) {
+        if (startAt == null) {
+            throw new IllegalArgumentException("일정 시작 시각은 필수입니다.");
+        }
+
+        MeetingSchedule schedule = new MeetingSchedule();
+        schedule.id = id;
+        schedule.meetingId = meetingId;
+        schedule.scheduleNumber = scheduleNumber;
+        schedule.bookId = bookId;
+        schedule.status = MeetingScheduleStatus.SCHEDULED;
+        schedule.startAt = startAt;
+        schedule.discussionNote = discussionNote;
+        schedule.createdAt = createdAt;
+        schedule.createdBy = createdBy;
+        return schedule;
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingScheduleJpaRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingScheduleJpaRepository.java
@@ -1,0 +1,24 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 모임 일정 JPA Repository
+public interface MeetingScheduleJpaRepository extends JpaRepository<MeetingSchedule, UUID> {
+
+    // 특정 모임의 일정 목록 조회
+    List<MeetingSchedule> findByMeetingId(UUID meetingId);
+
+    // 특정 모임의 상태별 일정 목록 조회
+    List<MeetingSchedule> findByMeetingIdAndStatus(UUID meetingId, MeetingScheduleStatus status);
+
+    // 특정 모임의 회차 번호로 일정 조회
+    Optional<MeetingSchedule> findByMeetingIdAndScheduleNumber(UUID meetingId, int scheduleNumber);
+
+    // 특정 모임 내 회차 번호 중복 여부 확인
+    boolean existsByMeetingIdAndScheduleNumber(UUID meetingId, int scheduleNumber);
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingScheduleRepositoryImpl.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingScheduleRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingScheduleRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+// 모임 일정 Repository 구현체
+@Repository
+@RequiredArgsConstructor
+public class MeetingScheduleRepositoryImpl implements MeetingScheduleRepository {
+
+    private final MeetingScheduleJpaRepository meetingScheduleJpaRepository;
+
+    // 일정 저장
+    @Override
+    public MeetingSchedule save(MeetingSchedule meetingSchedule) {
+        return meetingScheduleJpaRepository.save(meetingSchedule);
+    }
+
+    // ID로 일정 조회
+    @Override
+    public Optional<MeetingSchedule> findById(UUID scheduleId) {
+        return meetingScheduleJpaRepository.findById(scheduleId);
+    }
+
+    // 특정 모임의 전체 일정 조회
+    @Override
+    public List<MeetingSchedule> findByMeetingId(UUID meetingId) {
+        return meetingScheduleJpaRepository.findByMeetingId(meetingId);
+    }
+
+    // 특정 모임의 상태별 일정 조회
+    @Override
+    public List<MeetingSchedule> findByMeetingIdAndStatus(
+            UUID meetingId,
+            MeetingScheduleStatus status
+    ) {
+        return meetingScheduleJpaRepository.findByMeetingIdAndStatus(meetingId, status);
+    }
+
+    // 모임 + 회차 번호로 일정 조회
+    @Override
+    public Optional<MeetingSchedule> findByMeetingIdAndScheduleNumber(
+            UUID meetingId,
+            int scheduleNumber
+    ) {
+        return meetingScheduleJpaRepository.findByMeetingIdAndScheduleNumber(meetingId, scheduleNumber);
+    }
+
+    // 회차 번호 중복 여부 확인
+    @Override
+    public boolean existsByMeetingIdAndScheduleNumber(UUID meetingId, int scheduleNumber) {
+        return meetingScheduleJpaRepository.existsByMeetingIdAndScheduleNumber(meetingId, scheduleNumber);
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -36,6 +36,7 @@ public class MeetingController {
             @Valid @RequestBody CreateMeetingRequest req
     ) {
         CreateMeetingCommand command = new CreateMeetingCommand(
+                // TODO: 인증 컨텍스트 연결
                 req.hostId(),
                 req.bookId(),
                 req.title(),

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -1,12 +1,17 @@
 package com.pagely.meetingservice.meeting.presentation.controller;
 
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingCommand;
+import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingResult;
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingScheduleResult;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingSummaryResult;
 import com.pagely.meetingservice.meeting.application.service.MeetingApplicationService;
 import com.pagely.meetingservice.meeting.application.service.MeetingQueryService;
+import com.pagely.meetingservice.meeting.application.service.MeetingScheduleApplicationService;
 import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingRequest;
+import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingScheduleRequest;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingResponse;
+import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingScheduleResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingSummaryResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -29,6 +34,7 @@ public class MeetingController {
 
     private final MeetingApplicationService meetingApplicationService;
     private final MeetingQueryService meetingQueryService;
+    private final MeetingScheduleApplicationService meetingScheduleApplicationService;
 
     // 모임 생성
     @PostMapping
@@ -72,5 +78,26 @@ public class MeetingController {
     public MeetingResponse getMeeting(@PathVariable UUID meetingId) {
         MeetingResult result = meetingQueryService.getMeeting(meetingId);
         return MeetingResponse.from(result);
+    }
+
+    // 모임 일정 생성
+    @PostMapping("/{meetingId}/schedules")
+    public ResponseEntity<MeetingScheduleResponse> createMeetingSchedule(
+            @PathVariable UUID meetingId,
+            @Valid @RequestBody CreateMeetingScheduleRequest req
+    ) {
+        CreateMeetingScheduleCommand command = new CreateMeetingScheduleCommand(
+                meetingId,
+                req.bookId(),
+                req.startAt(),
+                req.discussionNote(),
+                // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경
+                UUID.fromString("00000000-0000-0000-0000-000000000001")
+        );
+
+        MeetingScheduleResult result = meetingScheduleApplicationService.createSchedule(command);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(MeetingScheduleResponse.from(result));
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
@@ -1,5 +1,8 @@
 package com.pagely.meetingservice.meeting.presentation.dto.request;
 
+import com.pagely.meetingservice.meeting.domain.model.MeetingType;
+import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
+import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -7,17 +10,13 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import com.pagely.meetingservice.meeting.domain.model.MeetingType;
-import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
-import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
-
 public record CreateMeetingRequest(
 
         @NotNull UUID hostId,
 
         String bookId,
 
-        @NotBlank @Size(max = 20) String title,
+        @NotBlank @Size(max = 100) String title,
 
         String description,
 

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingScheduleRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingScheduleRequest.java
@@ -1,0 +1,15 @@
+package com.pagely.meetingservice.meeting.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record CreateMeetingScheduleRequest(
+
+        String bookId,
+
+        @NotNull
+        LocalDateTime startAt,
+
+        String discussionNote
+) {
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingScheduleResponse.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingScheduleResponse.java
@@ -1,0 +1,34 @@
+package com.pagely.meetingservice.meeting.presentation.dto.response;
+
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingScheduleResult;
+import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MeetingScheduleResponse(
+        UUID id,
+        UUID meetingId,
+        int scheduleNumber,
+        String bookId,
+        MeetingScheduleStatus status,
+        LocalDateTime startAt,
+        String discussionNote,
+        LocalDateTime createdAt,
+        UUID createdBy
+) {
+
+    // Result를 API 응답 DTO로 변환
+    public static MeetingScheduleResponse from(MeetingScheduleResult result) {
+        return new MeetingScheduleResponse(
+                result.id(),
+                result.meetingId(),
+                result.scheduleNumber(),
+                result.bookId(),
+                result.status(),
+                result.startAt(),
+                result.discussionNote(),
+                result.createdAt(),
+                result.createdBy()
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 모임 일정 생성 API (POST /api/v1/meetings/{meetingId}/schedules) 구현
- MeetingSchedule 도메인 및 생성 로직 추가
- @JdbcTypeCode(SqlTypes.NAMED_ENUM) 적용
- Meeting / MeetingSchedule enum 컬럼 매핑 보완

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #17 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #17 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="833" height="771" alt="스크린샷 2026-04-26 오전 3 22 03" src="https://github.com/user-attachments/assets/f8ea5a21-3deb-41c8-a5f1-0f063165331d" />
<img width="834" height="536" alt="스크린샷 2026-04-26 오전 3 22 32" src="https://github.com/user-attachments/assets/1cffd0a2-89aa-4e3a-86d7-369bbc67b8ca" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회의 일정 생성 API 추가(회의별 일정 등록 및 응답 반환)
  * 회의 일정 관련 요청/응답 및 결과 표현 DTO 추가

* **개선 사항**
  * 회의 제목 길이 제한 확장(20자 → 100자)
  * 입력 검증 강화(일정 시작일 등 필수 항목 검사)
  * 데이터베이스 열거형 타입 매핑 개선 및 일정 번호 자동 증가 처리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->