### PR TITLE
Feat/23 모임 가입 신청 목록 조회 API

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinListSortPolicy.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinListSortPolicy.java
@@ -1,0 +1,24 @@
+package com.pagely.meetingservice.meeting.application.service;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
+import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MeetingJoinListSortPolicy {
+
+    public void sortForHostJoinList(List<MeetingJoin> joins) {
+        joins.sort(defaultHostListComparator());
+    }
+
+    private Comparator<MeetingJoin> defaultHostListComparator() {
+        Comparator<LocalDateTime> createdAtDesc =
+                Comparator.nullsLast(Comparator.<LocalDateTime>naturalOrder()).reversed();
+        return Comparator
+                .comparing((MeetingJoin j) -> j.getJoinStatus() != MeetingJoinStatus.PENDING)
+                .thenComparing(MeetingJoin::getCreatedAt, createdAtDesc);
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
@@ -1,18 +1,18 @@
 package com.pagely.meetingservice.meeting.application.service;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.pagely.meetingservice.meeting.application.dto.command.JoinMeetingCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingJoinResult;
 import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
+import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
 import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingJoinRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 // 가입 신청 서비스
@@ -22,34 +22,63 @@ public class MeetingJoinService {
 
     private final MeetingJoinRepository meetingJoinRepository;
     private final MeetingRepository meetingRepository;
+    private final MeetingJoinListSortPolicy meetingJoinListSortPolicy;
 
     // 생성자
-    public MeetingJoinService(MeetingJoinRepository meetingJoinRepository, MeetingRepository meetingRepository) {
+    public MeetingJoinService(MeetingJoinRepository meetingJoinRepository,
+                              MeetingRepository meetingRepository,
+                              MeetingJoinListSortPolicy meetingJoinListSortPolicy) {
         this.meetingJoinRepository = meetingJoinRepository;
         this.meetingRepository = meetingRepository;
+        this.meetingJoinListSortPolicy = meetingJoinListSortPolicy;
     }
-    
+
+    // 모임 가입 신청 목록 조회
+    public List<MeetingJoinResult> getMeetingJoinList(UUID meetingId, UUID requesterHostId,
+                                                      MeetingJoinStatus joinStatus) {
+        Meeting meeting = meetingRepository.findById(meetingId) // 모임 조회    
+                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+
+        if (!meeting.getHostId().equals(requesterHostId)) { // 모임장 검증
+            throw new IllegalArgumentException("모임장만 가입 신청 목록을 조회할 수 있습니다.");
+
+        }
+        List<MeetingJoin> joins;
+
+        if (joinStatus != null) {
+            joins = meetingJoinRepository.findByMeetingIdAndJoinStatus(meetingId, joinStatus);
+        } else {
+            joins = meetingJoinRepository.findByMeetingId(meetingId);
+        }
+
+        meetingJoinListSortPolicy.sortForHostJoinList(joins);
+
+        return joins.stream().map(MeetingJoinResult::from).toList();
+
+
+    }
+
     // 가입 신청 처리
     @Transactional
-    public MeetingJoinResult createMeetingJoin(JoinMeetingCommand command){
+    public MeetingJoinResult createMeetingJoin(JoinMeetingCommand command) {
         Meeting meeting = meetingRepository.findById(command.getMeetingId())
-        .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다"));
-    
+                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다"));
 
-    // 모집 상태가 RECRUITING인지 검사
-    if(meeting.getRecruitStatus() != RecruitStatus.RECRUITING){ 
-        throw new IllegalStateException("현재 모집 중인 모임이 아닙니다.");
+        // 모집 상태가 RECRUITING인지 검사
+        if (meeting.getRecruitStatus() != RecruitStatus.RECRUITING) {
+            throw new IllegalStateException("현재 모집 중인 모임이 아닙니다.");
+        }
+
+        // 중복 신청 여부 검사
+        if (meetingJoinRepository.existsByMeetingIdAndRecruitUserId(command.getMeetingId(),
+                command.getRecruitUserId())) {
+            throw new IllegalStateException("이미 가입 신청한 모임입니다.");
+        }
+
+        UUID joinId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        MeetingJoin join = command.toMeetingJoin(joinId, now);
+        MeetingJoin saved = meetingJoinRepository.save(join);
+        return MeetingJoinResult.from(saved);
     }
-
-    // 중복 신청 여부 검사
-    if(meetingJoinRepository.existsByMeetingIdAndRecruitUserId(command.getMeetingId(), command.getRecruitUserId())){
-        throw new IllegalStateException("이미 가입 신청한 모임입니다.");
-    }
-
-    UUID joinId = UUID.randomUUID();
-    LocalDateTime now = LocalDateTime.now();
-    MeetingJoin join = command.toMeetingJoin(joinId, now);
-    MeetingJoin saved = meetingJoinRepository.save(join);
-    return MeetingJoinResult.from(saved);
-}
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -228,4 +228,8 @@ public class Meeting {
     public UUID getCreatedBy() {
         return createdBy;
     }
+
+    public boolean canViewJoinApplications(UUID userId) {
+        return this.hostId.equals(userId);
+    }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingJoinRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingJoinRepository.java
@@ -26,4 +26,5 @@ public interface MeetingJoinRepository {
 
     // 이미 가입 신청했는지 확인
     boolean existsByMeetingIdAndRecruitUserId(UUID meetingId, UUID recruitUserId);
+
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -10,6 +10,7 @@ import com.pagely.meetingservice.meeting.application.service.MeetingJoinService;
 import com.pagely.meetingservice.meeting.application.service.MeetingQueryService;
 import com.pagely.meetingservice.meeting.application.service.MeetingScheduleCommandService;
 import com.pagely.meetingservice.meeting.application.service.MeetingScheduleQueryService;
+import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
 import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingRequest;
 import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingScheduleRequest;
 import com.pagely.meetingservice.meeting.presentation.dto.request.JoinMeetingRequest;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 // 모임 API 컨트롤러
@@ -128,5 +130,19 @@ public class MeetingController {
         MeetingScheduleResult result = meetingScheduleQueryService.getSchedule(meetingId, scheduleId);
 
         return MeetingScheduleResponse.from(result);
+    }
+
+    // 가입 신청 목록 조회
+    @GetMapping("/{meetingId}/join")
+    public List<MeetingJoinResponse> getMeetingJoinList(
+            @PathVariable UUID meetingId,
+            @RequestParam UUID hostId,
+            @RequestParam(required = false) MeetingJoinStatus joinStatus
+    ) {
+        List<MeetingJoinResult> results = meetingJoinService.getMeetingJoinList(meetingId, hostId, joinStatus);
+
+        return results.stream()
+                .map(MeetingJoinResponse::from)
+                .toList();
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- `GET /api/v1/meetings/{meetingId}/join` 모임장 전용 가입 신청 목록 조회 API 추가
- `hostId`로 모임장(`p_meeting.host_id`) 검증 -> 인증인가 도입 시 수정
- `joinStatus`로 `recruit_status` 필터 (`findByMeetingIdAndJoinStatus`)
- `MeetingJoinListSortPolicy` 기본 PENDING 우선, 동일 그룹 내 `created_at` 내림차순 정렬
- `MeetingJoinService#getMeetingJoinList`에서 조회·권한·정렬 후 `MeetingJoinResult` 반환, 컨트롤러에서 `MeetingJoinResponse`로 매핑

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #23   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #23  

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="372" height="81" alt="image" src="https://github.com/user-attachments/assets/08bf245e-613c-4248-ba36-b256a37eb596" />

<img width="673" height="558" alt="image" src="https://github.com/user-attachments/assets/fe862e33-a242-4e0a-8149-0792aa20b0f5" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - **페이징:** 후속 작업으로 `Pageable`/`Sort` 등 구현
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 미팅 참가 신청 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 참가 신청 상태별로 목록을 필터링할 수 있습니다.
  * 참가 신청이 상태와 날짜에 따라 자동으로 정렬됩니다.

* **Chores**
  * 코드 구조 및 포맷팅 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->