### PR TITLE
Feat/18 모임 일정 참석 등록 API 구현 및 PostgreSQL enum 매핑 적용

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingAttendanceResult.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/result/MeetingAttendanceResult.java
@@ -1,0 +1,33 @@
+package com.pagely.meetingservice.meeting.application.dto.result;
+
+import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 모임 일정 참석 등록 결과 DTO
+public record MeetingAttendanceResult(
+        UUID attendanceId,
+        UUID meetingId,
+        UUID scheduleId,
+        UUID userId,
+        AttendanceStatus status,
+        LocalDateTime checkedAt,
+        String note,
+        LocalDateTime createdAt
+) {
+
+    // 엔티티 → 결과 DTO 변환
+    public static MeetingAttendanceResult from(MeetingAttendance attendance) {
+        return new MeetingAttendanceResult(
+                attendance.getId(),
+                attendance.getMeetingId(),
+                attendance.getScheduleId(),
+                attendance.getUserId(),
+                attendance.getStatus(),
+                attendance.getCheckedAt(),
+                attendance.getNote(),
+                attendance.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
@@ -1,0 +1,65 @@
+package com.pagely.meetingservice.meeting.application.service;
+
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingAttendanceResult;
+import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingAttendanceRepository;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingScheduleRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// 모임 일정 참석 서비스
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MeetingAttendanceCommandService {
+
+    private final MeetingRepository meetingRepository;
+    private final MeetingScheduleRepository meetingScheduleRepository;
+    private final MeetingMemberRepository meetingMemberRepository;
+    private final MeetingAttendanceRepository meetingAttendanceRepository;
+
+    // 모임 일정 참석 등록
+    @Transactional
+    public MeetingAttendanceResult joinSchedule(UUID meetingId, UUID scheduleId, UUID userId) {
+        meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+
+        MeetingSchedule schedule = meetingScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("모임 일정이 존재하지 않습니다."));
+
+        if (!schedule.getMeetingId().equals(meetingId)) {
+            throw new IllegalArgumentException("해당 모임에 속한 일정이 아닙니다.");
+        }
+
+        boolean isMember = meetingMemberRepository.existsByMeetingIdAndUserId(meetingId, userId);
+        if (!isMember) {
+            throw new IllegalArgumentException("모임원만 일정 참석 등록이 가능합니다.");
+        }
+
+        boolean alreadyJoined = meetingAttendanceRepository.existsByScheduleIdAndUserId(scheduleId, userId);
+        if (alreadyJoined) {
+            throw new IllegalArgumentException("이미 참석 등록한 일정입니다.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        MeetingAttendance attendance = MeetingAttendance.create(
+                UUID.randomUUID(),
+                meetingId,
+                scheduleId,
+                userId,
+                now,
+                userId
+        );
+
+        MeetingAttendance saved = meetingAttendanceRepository.save(attendance);
+
+        return MeetingAttendanceResult.from(saved);
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingAttendance.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingAttendance.java
@@ -8,7 +8,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
+// 모임 일정 참석 엔티티
 @Entity
 @Table(name = "p_meeting_attendance")
 public class MeetingAttendance {
@@ -24,13 +27,14 @@ public class MeetingAttendance {
     @Column(name = "schedule_id", nullable = false)
     private UUID scheduleId;
 
-    // 출석 대상 유저 ID
+    // 참석 등록 유저 ID
     @Column(name = "user_id", nullable = false)
     private UUID userId;
 
     // 출석 상태
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "status", nullable = false, columnDefinition = "attendance_status")
     private AttendanceStatus status;
 
     // 출석 체크 시각
@@ -41,26 +45,75 @@ public class MeetingAttendance {
     @Column(name = "note", length = 255)
     private String note;
 
-    // 공통 감사 컬럼
+    // 생성일시
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    // 생성자 ID
     @Column(name = "created_by", nullable = false, updatable = false)
     private UUID createdBy;
 
+    // 수정일시
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    // 수정자 ID
     @Column(name = "updated_by")
     private UUID updatedBy;
 
+    // 삭제일시
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    // 삭제자 ID
     @Column(name = "deleted_by")
     private UUID deletedBy;
 
     protected MeetingAttendance() {
+    }
+
+    private MeetingAttendance(
+            UUID id,
+            UUID meetingId,
+            UUID scheduleId,
+            UUID userId,
+            AttendanceStatus status,
+            LocalDateTime checkedAt,
+            String note,
+            LocalDateTime createdAt,
+            UUID createdBy
+    ) {
+        this.id = id;
+        this.meetingId = meetingId;
+        this.scheduleId = scheduleId;
+        this.userId = userId;
+        this.status = status;
+        this.checkedAt = checkedAt;
+        this.note = note;
+        this.createdAt = createdAt;
+        this.createdBy = createdBy;
+    }
+
+    // 모임 일정 참석 등록 생성
+    public static MeetingAttendance create(
+            UUID id,
+            UUID meetingId,
+            UUID scheduleId,
+            UUID userId,
+            LocalDateTime now,
+            UUID createdBy
+    ) {
+        return new MeetingAttendance(
+                id,
+                meetingId,
+                scheduleId,
+                userId,
+                AttendanceStatus.PENDING,
+                null,
+                null,
+                now,
+                createdBy
+        );
     }
 
     // 출석 상태 변경
@@ -70,5 +123,41 @@ public class MeetingAttendance {
         this.checkedAt = LocalDateTime.now();
         this.updatedBy = updatedBy;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getMeetingId() {
+        return meetingId;
+    }
+
+    public UUID getScheduleId() {
+        return scheduleId;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public AttendanceStatus getStatus() {
+        return status;
+    }
+
+    public LocalDateTime getCheckedAt() {
+        return checkedAt;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public UUID getCreatedBy() {
+        return createdBy;
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_meeting_recruit")
@@ -26,7 +28,8 @@ public class MeetingJoin {
 
     // 신청 상태
     @Enumerated(EnumType.STRING)
-    @Column(name = "recruit_status", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "recruit_status", nullable = false, columnDefinition = "meeting_join_status")
     private MeetingJoinStatus joinStatus;
 
     // 신청 내용
@@ -75,49 +78,56 @@ public class MeetingJoin {
 //    }
 
 
+    public static MeetingJoin create( // 가입 신청 생성 팩토리 메서드
+                                      UUID id,
+                                      UUID meetingId,
+                                      UUID recruitUserId,
+                                      String content,
+                                      LocalDateTime createdAt,
+                                      UUID createdBy
+    ) {
+        MeetingJoin join = new MeetingJoin();
+        join.id = id;
+        join.meetingId = meetingId;
+        join.recruitUserId = recruitUserId;
+        join.joinStatus = MeetingJoinStatus.PENDING; // 생성 시 기본 상태를 PENDING으로 고정
+        join.content = content;
+        join.rejectReason = null; // 생성 시 거절 사유 없음
+        join.createdAt = createdAt;
+        join.createdBy = createdBy;
+        return join;
 
-public static MeetingJoin create( // 가입 신청 생성 팩토리 메서드
-    UUID id,
-    UUID meetingId,
-    UUID recruitUserId,
-    String content,
-    LocalDateTime createdAt,
-    UUID createdBy
-){
-    MeetingJoin join = new MeetingJoin();
-    join.id = id;
-    join.meetingId = meetingId;
-    join.recruitUserId = recruitUserId;
-    join.joinStatus = MeetingJoinStatus.PENDING; // 생성 시 기본 상태를 PENDING으로 고정
-    join.content = content;
-    join.rejectReason = null; // 생성 시 거절 사유 없음
-    join.createdAt = createdAt;
-    join.createdBy = createdBy;
-    return join;
+    }
 
-}
-public UUID getId(){
-    return id;
-}
-public UUID getMeetingId(){
-    return meetingId;
-}
-public UUID getRecruitUserId(){
-    return recruitUserId;
-}
-public MeetingJoinStatus getJoinStatus(){
-    return joinStatus;
-}
-public String getContent(){
-    return content;
-}
-public String getRejectReason(){
-    return rejectReason;
-}
-public LocalDateTime getCreatedAt(){
-    return createdAt;
-}
-public UUID getCreatedBy(){
-    return createdBy;
-}
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getMeetingId() {
+        return meetingId;
+    }
+
+    public UUID getRecruitUserId() {
+        return recruitUserId;
+    }
+
+    public MeetingJoinStatus getJoinStatus() {
+        return joinStatus;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getRejectReason() {
+        return rejectReason;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public UUID getCreatedBy() {
+        return createdBy;
+    }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_meeting_members")
@@ -24,14 +26,16 @@ public class MeetingMember {
     @Column(name = "user_id", nullable = false)
     private UUID userId;
 
-    // 멤버 역할
+    // 모임원 역할
     @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "role", nullable = false, columnDefinition = "meeting_member_role")
     private MeetingMemberRole role;
 
-    // 멤버 상태
+    // 모임원 상태
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "status", nullable = false, columnDefinition = "meeting_member_status")
     private MeetingMemberStatus status;
 
     // 결석 횟수

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingAttendanceJpaRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingAttendanceJpaRepository.java
@@ -1,0 +1,30 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 모임 일정 참석 JPA Repository
+public interface MeetingAttendanceJpaRepository extends JpaRepository<MeetingAttendance, UUID> {
+
+    // 일정 + 유저 기준 참석 조회
+    Optional<MeetingAttendance> findByScheduleIdAndUserIdAndDeletedAtIsNull(UUID scheduleId, UUID userId);
+
+    // 특정 일정의 참석 목록 조회
+    List<MeetingAttendance> findAllByScheduleIdAndDeletedAtIsNull(UUID scheduleId);
+
+    // 특정 일정의 상태별 참석 목록 조회
+    List<MeetingAttendance> findAllByScheduleIdAndStatusAndDeletedAtIsNull(
+            UUID scheduleId,
+            AttendanceStatus status
+    );
+
+    // 특정 모임에서 특정 유저의 참석 목록 조회
+    List<MeetingAttendance> findAllByMeetingIdAndUserIdAndDeletedAtIsNull(UUID meetingId, UUID userId);
+
+    // 특정 일정에 이미 참석 등록했는지 확인
+    boolean existsByScheduleIdAndUserIdAndDeletedAtIsNull(UUID scheduleId, UUID userId);
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingAttendanceRepositoryImpl.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingAttendanceRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingAttendanceRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+// 모임 일정 참석 Repository 구현체
+@Repository
+@RequiredArgsConstructor
+public class MeetingAttendanceRepositoryImpl implements MeetingAttendanceRepository {
+
+    private final MeetingAttendanceJpaRepository meetingAttendanceJpaRepository;
+
+    // 출석 저장
+    @Override
+    public MeetingAttendance save(MeetingAttendance meetingAttendance) {
+        return meetingAttendanceJpaRepository.save(meetingAttendance);
+    }
+
+    // ID로 출석 조회
+    @Override
+    public Optional<MeetingAttendance> findById(UUID attendanceId) {
+        return meetingAttendanceJpaRepository.findById(attendanceId);
+    }
+
+    // 일정 + 유저 기준 출석 조회
+    @Override
+    public Optional<MeetingAttendance> findByScheduleIdAndUserId(UUID scheduleId, UUID userId) {
+        return meetingAttendanceJpaRepository.findByScheduleIdAndUserIdAndDeletedAtIsNull(
+                scheduleId,
+                userId
+        );
+    }
+
+    // 특정 일정의 출석부 조회
+    @Override
+    public List<MeetingAttendance> findByScheduleId(UUID scheduleId) {
+        return meetingAttendanceJpaRepository.findAllByScheduleIdAndDeletedAtIsNull(scheduleId);
+    }
+
+    // 특정 일정의 상태별 출석 조회
+    @Override
+    public List<MeetingAttendance> findByScheduleIdAndStatus(UUID scheduleId, AttendanceStatus status) {
+        return meetingAttendanceJpaRepository.findAllByScheduleIdAndStatusAndDeletedAtIsNull(
+                scheduleId,
+                status
+        );
+    }
+
+    // 특정 모임에서 내 출석 목록 조회
+    @Override
+    public List<MeetingAttendance> findByMeetingIdAndUserId(UUID meetingId, UUID userId) {
+        return meetingAttendanceJpaRepository.findAllByMeetingIdAndUserIdAndDeletedAtIsNull(
+                meetingId,
+                userId
+        );
+    }
+
+    // 특정 일정에 이미 출석 등록했는지 확인
+    @Override
+    public boolean existsByScheduleIdAndUserId(UUID scheduleId, UUID userId) {
+        return meetingAttendanceJpaRepository.existsByScheduleIdAndUserIdAndDeletedAtIsNull(
+                scheduleId,
+                userId
+        );
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingMemberJpaRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingMemberJpaRepository.java
@@ -1,0 +1,44 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberRole;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberStatus;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 모임 멤버 JPA Repository
+public interface MeetingMemberJpaRepository extends JpaRepository<MeetingMember, UUID> {
+
+    // 모임과 유저 기준 멤버 조회
+    Optional<MeetingMember> findByMeetingIdAndUserIdAndDeletedAtIsNull(UUID meetingId, UUID userId);
+
+    // 특정 모임의 전체 멤버 조회
+    List<MeetingMember> findAllByMeetingIdAndDeletedAtIsNull(UUID meetingId);
+
+    // 특정 모임의 상태별 멤버 조회
+    List<MeetingMember> findAllByMeetingIdAndStatusAndDeletedAtIsNull(
+            UUID meetingId,
+            MeetingMemberStatus status
+    );
+
+    // 특정 모임의 역할별 멤버 조회
+    List<MeetingMember> findAllByMeetingIdAndRoleAndDeletedAtIsNull(
+            UUID meetingId,
+            MeetingMemberRole role
+    );
+
+    // 특정 모임의 활성 멤버 수 조회
+    long countByMeetingIdAndStatusAndDeletedAtIsNull(
+            UUID meetingId,
+            MeetingMemberStatus status
+    );
+
+    // 특정 유저가 해당 모임의 활성 멤버인지 확인
+    boolean existsByMeetingIdAndUserIdAndStatusAndDeletedAtIsNull(
+            UUID meetingId,
+            UUID userId,
+            MeetingMemberStatus status
+    );
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingMemberRepositoryImpl.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingMemberRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberRole;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberStatus;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+// 모임 멤버 Repository 구현체
+@Repository
+@RequiredArgsConstructor
+public class MeetingMemberRepositoryImpl implements MeetingMemberRepository {
+
+    private final MeetingMemberJpaRepository meetingMemberJpaRepository;
+
+    // 멤버 저장
+    @Override
+    public MeetingMember save(MeetingMember meetingMember) {
+        return meetingMemberJpaRepository.save(meetingMember);
+    }
+
+    // ID로 멤버 조회
+    @Override
+    public Optional<MeetingMember> findById(UUID memberId) {
+        return meetingMemberJpaRepository.findById(memberId);
+    }
+
+    // 모임과 유저 기준 멤버 조회
+    @Override
+    public Optional<MeetingMember> findByMeetingIdAndUserId(UUID meetingId, UUID userId) {
+        return meetingMemberJpaRepository.findByMeetingIdAndUserIdAndDeletedAtIsNull(meetingId, userId);
+    }
+
+    // 특정 모임의 전체 멤버 조회
+    @Override
+    public List<MeetingMember> findByMeetingId(UUID meetingId) {
+        return meetingMemberJpaRepository.findAllByMeetingIdAndDeletedAtIsNull(meetingId);
+    }
+
+    // 특정 모임의 상태별 멤버 조회
+    @Override
+    public List<MeetingMember> findByMeetingIdAndStatus(UUID meetingId, MeetingMemberStatus status) {
+        return meetingMemberJpaRepository.findAllByMeetingIdAndStatusAndDeletedAtIsNull(meetingId, status);
+    }
+
+    // 특정 모임의 역할별 멤버 조회
+    @Override
+    public List<MeetingMember> findByMeetingIdAndRole(UUID meetingId, MeetingMemberRole role) {
+        return meetingMemberJpaRepository.findAllByMeetingIdAndRoleAndDeletedAtIsNull(meetingId, role);
+    }
+
+    // 특정 모임의 활성 멤버 수 조회
+    @Override
+    public long countByMeetingIdAndStatus(UUID meetingId, MeetingMemberStatus status) {
+        return meetingMemberJpaRepository.countByMeetingIdAndStatusAndDeletedAtIsNull(meetingId, status);
+    }
+
+    // 특정 유저가 해당 모임의 활성 멤버인지 확인
+    @Override
+    public boolean existsByMeetingIdAndUserId(UUID meetingId, UUID userId) {
+        return meetingMemberJpaRepository.existsByMeetingIdAndUserIdAndStatusAndDeletedAtIsNull(
+                meetingId,
+                userId,
+                MeetingMemberStatus.ACTIVE
+        );
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -153,6 +153,9 @@ public class MeetingController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(MeetingAttendanceResponse.from(result));
+
+    }
+
     // 가입 신청 목록 조회
     @GetMapping("/{meetingId}/join")
     public List<MeetingJoinResponse> getMeetingJoinList(

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -1,10 +1,12 @@
 package com.pagely.meetingservice.meeting.presentation.controller;
 
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingAttendanceResult;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingJoinResult;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingResult;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingScheduleResult;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingSummaryResult;
+import com.pagely.meetingservice.meeting.application.service.MeetingAttendanceCommandService;
 import com.pagely.meetingservice.meeting.application.service.MeetingCommandService;
 import com.pagely.meetingservice.meeting.application.service.MeetingJoinService;
 import com.pagely.meetingservice.meeting.application.service.MeetingQueryService;
@@ -13,6 +15,7 @@ import com.pagely.meetingservice.meeting.application.service.MeetingScheduleQuer
 import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingRequest;
 import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingScheduleRequest;
 import com.pagely.meetingservice.meeting.presentation.dto.request.JoinMeetingRequest;
+import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingAttendanceResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingJoinResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingScheduleResponse;
@@ -41,6 +44,7 @@ public class MeetingController {
     private final MeetingJoinService meetingJoinService;
     private final MeetingScheduleCommandService meetingScheduleCommandService;
     private final MeetingScheduleQueryService meetingScheduleQueryService;
+    private final MeetingAttendanceCommandService meetingAttendanceCommandService;
 
     // 모임 생성
     @PostMapping
@@ -128,5 +132,24 @@ public class MeetingController {
         MeetingScheduleResult result = meetingScheduleQueryService.getSchedule(meetingId, scheduleId);
 
         return MeetingScheduleResponse.from(result);
+    }
+
+    // 모임 일정 참석 등록
+    @PostMapping("/{meetingId}/schedules/{scheduleId}/join")
+    public ResponseEntity<MeetingAttendanceResponse> joinMeetingSchedule(
+            @PathVariable UUID meetingId,
+            @PathVariable UUID scheduleId
+    ) {
+        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경
+        UUID userId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+        MeetingAttendanceResult result = meetingAttendanceCommandService.joinSchedule(
+                meetingId,
+                scheduleId,
+                userId
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(MeetingAttendanceResponse.from(result));
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingAttendanceResponse.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingAttendanceResponse.java
@@ -1,0 +1,33 @@
+package com.pagely.meetingservice.meeting.presentation.dto.response;
+
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingAttendanceResult;
+import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 모임 일정 참석 등록 응답 DTO
+public record MeetingAttendanceResponse(
+        UUID attendanceId,
+        UUID meetingId,
+        UUID scheduleId,
+        UUID userId,
+        AttendanceStatus status,
+        LocalDateTime checkedAt,
+        String note,
+        LocalDateTime createdAt
+) {
+
+    // 결과 DTO → 응답 DTO 변환
+    public static MeetingAttendanceResponse from(MeetingAttendanceResult result) {
+        return new MeetingAttendanceResponse(
+                result.attendanceId(),
+                result.meetingId(),
+                result.scheduleId(),
+                result.userId(),
+                result.status(),
+                result.checkedAt(),
+                result.note(),
+                result.createdAt()
+        );
+    }
+}


### PR DESCRIPTION
일정 참가시 해당 일정 출석부에 추가되도록 구현. (모임 일정 참석 테이블을 따로 두지 않음)

- 모임 일정 참석 등록 API 구현 (POST /meetings/{meetingId}/schedules/{scheduleId}/join)
- MeetingAttendance 도메인 생성 로직 추가 (create 메서드)
- 모임/일정/모임원 검증 및 중복 참석 방지 로직 구현
- MeetingAttendanceRepository 저장 로직 추가
- PostgreSQL enum 타입 매핑 적용 (attendance_status, meeting_member_status 등)
- MeetingJoin 엔티티 enum 매핑 누락 수정
- MeetingMember enum 매핑 보완


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
-

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #18 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #18 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="834" height="453" alt="스크린샷 2026-04-26 오후 9 13 52" src="https://github.com/user-attachments/assets/c894855f-8a84-4440-baac-199264490dcd" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 모임 스케줄 참석 등록 기능이 추가되었습니다. 사용자는 특정 스케줄에 참석을 등록할 수 있습니다.
  * 참석 등록 API(POST /{meetingId}/schedules/{scheduleId}/join)를 통해 참석이 생성되며 201 응답을 반환합니다.
  * 응답에 참석 ID, 모임/스케줄/사용자 식별자, 참석 상태, 체크 시각, 생성 시각 및 메모가 포함됩니다.
  * 중복 등록 방지 및 모임 멤버 확인 등 서버측 검증으로 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->