### PR TITLE
Refactor/36 모임 서비스 예외 처리 통합 및 ErrorCode 적용

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
@@ -1,7 +1,12 @@
 package com.pagely.meetingservice.meeting.application.service;
 
+import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateAttendanceStatusCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingAttendanceResult;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingAttendanceErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
 import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
@@ -30,23 +35,23 @@ public class MeetingAttendanceCommandService {
     @Transactional
     public MeetingAttendanceResult joinSchedule(UUID meetingId, UUID scheduleId, UUID userId) {
         meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         MeetingSchedule schedule = meetingScheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new IllegalArgumentException("모임 일정이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
         if (!schedule.getMeetingId().equals(meetingId)) {
-            throw new IllegalArgumentException("해당 모임에 속한 일정이 아닙니다.");
+            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
         }
 
         boolean isMember = meetingMemberRepository.existsByMeetingIdAndUserId(meetingId, userId);
         if (!isMember) {
-            throw new IllegalArgumentException("모임원만 일정 참석 등록이 가능합니다.");
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_MEMBER_CAN_JOIN_SCHEDULE);
         }
 
         boolean alreadyJoined = meetingAttendanceRepository.existsByScheduleIdAndUserId(scheduleId, userId);
         if (alreadyJoined) {
-            throw new IllegalArgumentException("이미 참석 등록한 일정입니다.");
+            throw new BusinessException(MeetingAttendanceErrorCode.ATTENDANCE_ALREADY_EXISTS);
         }
 
         LocalDateTime now = LocalDateTime.now();
@@ -69,27 +74,27 @@ public class MeetingAttendanceCommandService {
     @Transactional
     public MeetingAttendanceResult changeAttendanceStatus(UpdateAttendanceStatusCommand command) {
         meetingRepository.findById(command.meetingId())
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         MeetingSchedule schedule = meetingScheduleRepository.findById(command.scheduleId())
-                .orElseThrow(() -> new IllegalArgumentException("모임 일정이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
         if (!schedule.getMeetingId().equals(command.meetingId())) {
-            throw new IllegalArgumentException("해당 모임에 속한 일정이 아닙니다.");
+            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
         }
 
         if (!schedule.isOngoing()) {
-            throw new IllegalArgumentException("진행중인 일정에서만 출석 상태를 변경할 수 있습니다.");
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ONGOING_SCHEDULE_CAN_CHANGE_ATTENDANCE);
         }
 
         MeetingMember updater = meetingMemberRepository.findByMeetingIdAndUserId(
                         command.meetingId(),
                         command.updatedBy()
                 )
-                .orElseThrow(() -> new IllegalArgumentException("모임원만 출석 상태를 변경할 수 있습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED));
 
         if (!updater.isActive() || !updater.isHost()) {
-            throw new IllegalArgumentException("모임장만 출석 상태를 변경할 수 있습니다.");
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_HOST_CAN_CHANGE_ATTENDANCE);
         }
 
         boolean targetIsMember = meetingMemberRepository.existsByMeetingIdAndUserId(
@@ -97,14 +102,14 @@ public class MeetingAttendanceCommandService {
                 command.userId()
         );
         if (!targetIsMember) {
-            throw new IllegalArgumentException("출석 상태 변경 대상 유저가 해당 모임원이 아닙니다.");
+            throw new BusinessException(MeetingAttendanceErrorCode.ATTENDANCE_USER_NOT_MEETING_MEMBER);
         }
 
         MeetingAttendance attendance = meetingAttendanceRepository.findByScheduleIdAndUserId(
                         command.scheduleId(),
                         command.userId()
                 )
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저의 참석 등록 내역이 없습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingAttendanceErrorCode.ATTENDANCE_NOT_FOUND));
 
         attendance.changeStatus(
                 command.status(),

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceQueryService.java
@@ -1,6 +1,11 @@
 package com.pagely.meetingservice.meeting.application.service;
 
+import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingAttendanceResult;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingAttendanceErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
 import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingAttendanceRepository;
@@ -31,20 +36,20 @@ public class MeetingAttendanceQueryService {
             UUID userId
     ) {
         meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         MeetingSchedule schedule = meetingScheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new IllegalArgumentException("모임 일정이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
         if (!schedule.getMeetingId().equals(meetingId)) {
-            throw new IllegalArgumentException("해당 모임에 속한 일정이 아닙니다.");
+            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
         }
 
         MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(meetingId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("모임원만 출석부를 조회할 수 있습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED));
 
         if (!member.isActive() || !member.isHost()) {
-            throw new IllegalArgumentException("모임장만 전체 출석부를 조회할 수 있습니다.");
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_HOST_CAN_VIEW_ATTENDANCES);
         }
 
         return meetingAttendanceRepository.findByScheduleId(scheduleId)
@@ -56,11 +61,11 @@ public class MeetingAttendanceQueryService {
     // 내 출석부 조회
     public List<MeetingAttendanceResult> getMyAttendances(UUID meetingId, UUID userId) {
         meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         boolean isMember = meetingMemberRepository.existsByMeetingIdAndUserId(meetingId, userId);
         if (!isMember) {
-            throw new IllegalArgumentException("모임원만 내 출석부를 조회할 수 있습니다.");
+            throw new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED);
         }
 
         return meetingAttendanceRepository.findByMeetingIdAndUserId(meetingId, userId)

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
@@ -1,7 +1,10 @@
 package com.pagely.meetingservice.meeting.application.service;
 
+import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.command.JoinMeetingCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingJoinResult;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingJoinErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
@@ -44,10 +47,10 @@ public class MeetingJoinService {
     public List<MeetingJoinResult> getMeetingJoinList(UUID meetingId, UUID requesterHostId,
                                                       MeetingJoinStatus joinStatus) {
         Meeting meeting = meetingRepository.findById(meetingId) // 모임 조회    
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         if (!meeting.getHostId().equals(requesterHostId)) { // 모임장 검증
-            throw new IllegalArgumentException("모임장만 가입 신청 목록을 조회할 수 있습니다.");
+            throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_VIEW_JOIN_LIST);
 
         }
         List<MeetingJoin> joins;
@@ -69,17 +72,17 @@ public class MeetingJoinService {
     @Transactional
     public MeetingJoinResult createMeetingJoin(JoinMeetingCommand command) {
         Meeting meeting = meetingRepository.findById(command.meetingId())
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다"));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         // 모집 상태가 RECRUITING인지 검사
         if (meeting.getRecruitStatus() != RecruitStatus.RECRUITING) {
-            throw new IllegalStateException("현재 모집 중인 모임이 아닙니다.");
+            throw new BusinessException(MeetingJoinErrorCode.NOT_RECRUITING_MEETING);
         }
 
         // 중복 신청 여부 검사
         if (meetingJoinRepository.existsByMeetingIdAndRecruitUserId(command.meetingId(),
                 command.recruitUserId())) {
-            throw new IllegalStateException("이미 가입 신청한 모임입니다.");
+            throw new BusinessException(MeetingJoinErrorCode.MEETING_JOIN_ALREADY_EXISTS);
         }
 
         UUID joinId = UUID.randomUUID();
@@ -94,28 +97,28 @@ public class MeetingJoinService {
     public MeetingJoinResult approveMeetingJoin(UUID meetingId, UUID joinId, UUID hostId) {
 
         Meeting meeting = meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다"));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         if (!meeting.getHostId().equals(hostId)) { // 모임장 검증
-            throw new IllegalStateException("모임장만 가입 승인할 수 있습니다.");
+            throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_APPROVE_JOIN);
         }
 
         MeetingJoin join = meetingJoinRepository.findById(joinId)
-                .orElseThrow(() -> new IllegalArgumentException("가입 신청이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingJoinErrorCode.MEETING_JOIN_NOT_FOUND));
 
         if (!join.getMeetingId().equals(meetingId)) {
-            throw new IllegalArgumentException("해당 모임의 가입 신청이 아닙니다.");
+            throw new BusinessException(MeetingJoinErrorCode.JOIN_NOT_FOR_MEETING);
         }
 
         if (meetingMemberRepository.existsByMeetingIdAndUserId(meetingId,
                 join.getRecruitUserId())) { // 이미 모임에 참여중인 사용자 검증
-            throw new IllegalStateException("이미 모임에 참여중인 사용자입니다.");
+            throw new BusinessException(MeetingJoinErrorCode.ALREADY_MEETING_MEMBER);
         }
 
         long activeCount = meetingMemberRepository.countByMeetingIdAndStatus(meetingId, MeetingMemberStatus.ACTIVE);
 
         if (activeCount >= meeting.getRecruitMax()) { // 모임 정원 검증
-            throw new IllegalStateException("모임 정원이 마감되었습니다.");
+            throw new BusinessException(MeetingJoinErrorCode.MEETING_RECRUIT_FULL);
         }
 
         join.approve(hostId);

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingQueryService.java
@@ -1,7 +1,9 @@
 package com.pagely.meetingservice.meeting.application.service;
 
+import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingResult;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingSummaryResult;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
 import java.util.List;
@@ -28,7 +30,7 @@ public class MeetingQueryService {
     public MeetingResult getMeeting(UUID meetingId) {
         // TODO: 에러처리
         Meeting meeting = meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다"));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         return MeetingResult.from(meeting);
     }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleCommandService.java
@@ -1,8 +1,12 @@
 package com.pagely.meetingservice.meeting.application.service;
 
+import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateScheduleStatusCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingScheduleResult;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
@@ -32,11 +36,11 @@ public class MeetingScheduleCommandService {
     @Transactional
     public MeetingScheduleResult createSchedule(CreateMeetingScheduleCommand command) {
         Meeting meeting = meetingRepository.findById(command.meetingId())
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         // TODO: 인증 컨텍스트 연결 후 모임장 권한 검증
-//        if (!meeting.getHostId().equals(...) {
-//            throw new IllegalArgumentException("모임장만 일정을 생성할 수 있습니다.");
+//        if (!meeting.getHostId().equals(hostId)) {
+//            throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_APPROVE_JOIN);
 //        }
 
         int nextScheduleNumber = calculateNextScheduleNumber(command.meetingId());
@@ -61,23 +65,23 @@ public class MeetingScheduleCommandService {
     @Transactional
     public MeetingScheduleResult changeScheduleStatus(UpdateScheduleStatusCommand command) {
         meetingRepository.findById(command.meetingId())
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
         MeetingSchedule schedule = meetingScheduleRepository.findById(command.scheduleId())
-                .orElseThrow(() -> new IllegalArgumentException("모임 일정이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
         if (!schedule.getMeetingId().equals(command.meetingId())) {
-            throw new IllegalArgumentException("해당 모임에 속한 일정이 아닙니다.");
+            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
         }
 
         MeetingMember updater = meetingMemberRepository.findByMeetingIdAndUserId(
                         command.meetingId(),
                         command.updatedBy()
                 )
-                .orElseThrow(() -> new IllegalArgumentException("모임원만 일정 상태를 변경할 수 있습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED));
 
         if (!updater.isActive() || !updater.isHost()) {
-            throw new IllegalArgumentException("모임장만 일정 상태를 변경할 수 있습니다.");
+            throw new BusinessException(MeetingScheduleErrorCode.ONLY_HOST_CAN_CHANGE_SCHEDULE_STATUS);
         }
 
         if (command.status() == MeetingScheduleStatus.FINISHED) {

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleQueryService.java
@@ -1,6 +1,9 @@
 package com.pagely.meetingservice.meeting.application.service;
 
+import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingScheduleResult;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingScheduleRepository;
@@ -37,7 +40,7 @@ public class MeetingScheduleQueryService {
                         scheduleId,
                         meetingId
                 )
-                .orElseThrow(() -> new IllegalArgumentException("모임 일정이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
         return MeetingScheduleResult.from(schedule);
     }
@@ -45,6 +48,6 @@ public class MeetingScheduleQueryService {
     // 모임 존재 여부 검증
     private void validateMeetingExists(UUID meetingId) {
         meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new IllegalArgumentException("모임이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -1,5 +1,7 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -133,11 +135,11 @@ public class Meeting {
     ) {
         if (recruitMax <= 0) {
             // TODO: 에러처리
-            throw new IllegalArgumentException("모집 인원은 1명 이상이어야 합니다.");
+            throw new BusinessException(MeetingErrorCode.INVALID_RECRUIT_MAX);
         }
         if (recruitStartAt.isAfter(recruitEndAt)) {
             // TODO: 에러처리
-            throw new IllegalArgumentException("모집 시작 시각은 종료 시각보다 늦을 수 없습니다.");
+            throw new BusinessException(MeetingErrorCode.INVALID_RECRUIT_PERIOD);
         }
 
         Meeting meeting = new Meeting();

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
@@ -1,5 +1,7 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingJoinErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -66,7 +68,7 @@ public class MeetingJoin {
     public void approve(UUID approvedBy) {
 
         if (this.joinStatus != MeetingJoinStatus.PENDING) {
-            throw new IllegalArgumentException("승인 대기 상태의 신청만 승인할 수 있습니다.");
+            throw new BusinessException(MeetingJoinErrorCode.INVALID_JOIN_STATUS);
         }
         this.joinStatus = MeetingJoinStatus.APPROVED;
         this.updatedBy = approvedBy;

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingSchedule.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingSchedule.java
@@ -1,5 +1,7 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -86,7 +88,7 @@ public class MeetingSchedule {
             UUID createdBy
     ) {
         if (startAt == null) {
-            throw new IllegalArgumentException("일정 시작 시각은 필수입니다.");
+            throw new BusinessException(MeetingScheduleErrorCode.INVALID_SCHEDULE_START_AT);
         }
 
         MeetingSchedule schedule = new MeetingSchedule();


### PR DESCRIPTION
Related to: #36

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
* 기존 IllegalArgumentException, IllegalStateException 제거
* BusinessException + ErrorCode 기반으로 예외 처리 통합
* 도메인별 ErrorCode 분리 적용
    * Meeting / Join / Member / Schedule / Attendance
* 서비스 및 도메인 로직 전반에 예외 처리 일관성 적용

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #36 

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 회의 관련 서비스의 에러 처리 체계를 표준화했습니다.
  * 회의, 일정, 참가, 멤버 관리 등 전반적인 오류 처리의 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->