### PR TITLE
Feat/41 모임/일정/가입/출석 조회 API 페이징 처리 적용

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceQueryService.java
@@ -16,6 +16,8 @@ import com.pagely.meetingservice.meeting.domain.repository.MeetingScheduleReposi
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,19 +32,18 @@ public class MeetingAttendanceQueryService {
     private final MeetingMemberRepository meetingMemberRepository;
     private final MeetingAttendanceRepository meetingAttendanceRepository;
 
-    // 특정 일정의 출석부 조회
-    public List<MeetingAttendanceResult> getScheduleAttendances(
+    // 특정 일정의 출석부 조회 - 페이징 처리
+    public Page<MeetingAttendanceResult> getScheduleAttendances(
             UUID meetingId,
             UUID scheduleId,
-            UUID userId
+            UUID userId,
+            Pageable pageable
     ) {
         validateScheduleAttendanceViewPermission(meetingId, scheduleId, userId);
 
-        // 해당 일정에 등록된 출석 정보를 조회 후 결과 DTO로 변환
-        return meetingAttendanceRepository.findByScheduleId(scheduleId)
-                .stream()
-                .map(MeetingAttendanceResult::from)
-                .toList();
+        // 해당 일정에 등록된 출석 정보를 페이징 조회 후 결과 DTO로 변환
+        return meetingAttendanceRepository.findByScheduleId(scheduleId, pageable)
+                .map(MeetingAttendanceResult::from);
     }
 
     // 특정 일정의 출석 통계 조회
@@ -52,43 +53,43 @@ public class MeetingAttendanceQueryService {
             UUID userId
     ) {
         // 출석부 조회 권한과 동일한 권한 정책을 적용한다.
-        // 즉, 특정 일정의 전체 출석 통계는 ACTIVE 상태의 모임장만 조회 가능하다.
         validateScheduleAttendanceViewPermission(meetingId, scheduleId, userId);
 
+        // 통계는 페이징된 데이터가 아니라 전체 출석 기록 기준으로 계산한다.
         List<MeetingAttendanceResult> attendances = meetingAttendanceRepository.findByScheduleId(scheduleId)
                 .stream()
                 .map(MeetingAttendanceResult::from)
                 .toList();
 
-        // 조회된 출석 상태를 기준으로 통계를 즉시 계산한다.
-        // 지각 3회 = 결석 1회 환산 정책도 여기서 계산된다.
         return AttendanceStatisticsResult.from(attendances);
     }
 
-    // 내 출석부 조회
-    public List<MeetingAttendanceResult> getMyAttendances(UUID meetingId, UUID userId) {
+    // 내 출석부 조회 - 페이징 처리
+    public Page<MeetingAttendanceResult> getMyAttendances(
+            UUID meetingId,
+            UUID userId,
+            Pageable pageable
+    ) {
         validateMyAttendanceViewPermission(meetingId, userId);
 
-        // 해당 사용자의 모임 내 출석 이력을 조회 후 결과 DTO로 변환
-        return meetingAttendanceRepository.findByMeetingIdAndUserId(meetingId, userId)
-                .stream()
-                .map(MeetingAttendanceResult::from)
-                .toList();
+        // 해당 사용자의 모임 내 출석 이력을 페이징 조회 후 결과 DTO로 변환
+        return meetingAttendanceRepository.findByMeetingIdAndUserId(meetingId, userId, pageable)
+                .map(MeetingAttendanceResult::from);
     }
 
     // 내 출석 통계 조회
     public AttendanceStatisticsResult getMyAttendanceStatistics(UUID meetingId, UUID userId) {
-        // 내 출석 통계는 해당 모임의 멤버만 조회 가능하다.
         validateMyAttendanceViewPermission(meetingId, userId);
 
-        List<MeetingAttendanceResult> attendances = meetingAttendanceRepository.findByMeetingIdAndUserId(meetingId,
-                        userId)
+        // 통계는 페이징된 데이터가 아니라 전체 출석 이력 기준으로 계산한다.
+        List<MeetingAttendanceResult> attendances = meetingAttendanceRepository.findByMeetingIdAndUserId(
+                        meetingId,
+                        userId
+                )
                 .stream()
                 .map(MeetingAttendanceResult::from)
                 .toList();
 
-        // 내 출석 이력을 기준으로 출석/지각/결석/사유결석 통계를 계산한다.
-        // LATE 상태 자체는 유지하고, 지각 3회 환산은 통계 값에만 반영한다.
         return AttendanceStatisticsResult.from(attendances);
     }
 
@@ -98,26 +99,19 @@ public class MeetingAttendanceQueryService {
             UUID scheduleId,
             UUID userId
     ) {
-        // 요청한 모임이 실제 존재하는지 확인
         meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
-        // 출석부를 조회할 일정이 실제 존재하는지 확인
         MeetingSchedule schedule = meetingScheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
-        // 일정이 요청한 모임에 속한 일정인지 검증
-        // 다른 모임의 scheduleId로 출석부를 조회하는 것을 방지
         if (!schedule.getMeetingId().equals(meetingId)) {
             throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
         }
 
-        // 출석부 조회 요청자가 해당 모임의 멤버인지 확인
         MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(meetingId, userId)
                 .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED));
 
-        // 출석부 전체 조회는 ACTIVE 상태의 모임장만 가능
-        // 일반 모임원이 다른 회원들의 출석 정보를 조회하는 것을 방지
         if (!member.isActive() || !member.isHost()) {
             throw new BusinessException(MeetingAttendanceErrorCode.ONLY_HOST_CAN_VIEW_ATTENDANCES);
         }
@@ -125,12 +119,9 @@ public class MeetingAttendanceQueryService {
 
     // 내 출석부 조회 권한 검증
     private void validateMyAttendanceViewPermission(UUID meetingId, UUID userId) {
-        // 요청한 모임이 실제 존재하는지 확인
         meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
-        // 내 출석부 조회는 해당 모임의 멤버만 가능
-        // 모임에 속하지 않은 사용자가 출석 이력을 조회하는 것을 방지
         boolean isMember = meetingMemberRepository.existsByMeetingIdAndUserId(meetingId, userId);
         if (!isMember) {
             throw new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED);

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
@@ -17,8 +17,9 @@ import com.pagely.meetingservice.meeting.domain.repository.MeetingJoinRepository
 import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,31 +47,32 @@ public class MeetingJoinService {
         this.meetingMemberRepository = meetingMemberRepository;
     }
 
-    // 모임 가입 신청 목록 조회
-    public List<MeetingJoinResult> getMeetingJoinList(UUID meetingId, UUID requesterHostId,
-                                                      MeetingJoinStatus joinStatus) {
-        Meeting meeting = meetingRepository.findById(meetingId) // 모임 조회    
+    // 모임 가입 신청 목록 조회 - 페이징 처리
+    public Page<MeetingJoinResult> getMeetingJoinList(
+            UUID meetingId,
+            UUID requesterHostId,
+            MeetingJoinStatus joinStatus,
+            Pageable pageable
+    ) {
+        // 모임 조회
+        Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
+        // 모집 기간이 종료된 경우 모집 상태를 CLOSED로 동기화
         syncRecruitClosedPeriod(meeting);
 
-        if (!meeting.getHostId().equals(requesterHostId)) { // 모임장 검증
+        // 모임장만 가입 신청 목록을 조회할 수 있음
+        if (!meeting.getHostId().equals(requesterHostId)) {
             throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_VIEW_JOIN_LIST);
-
-        }
-        List<MeetingJoin> joins;
-
-        if (joinStatus != null) {
-            joins = meetingJoinRepository.findByMeetingIdAndJoinStatus(meetingId, joinStatus);
-        } else {
-            joins = meetingJoinRepository.findByMeetingId(meetingId);
         }
 
-        meetingJoinListSortPolicy.sortForHostJoinList(joins);
+        // 가입 상태 조건이 있으면 상태별 조회, 없으면 전체 조회
+        Page<MeetingJoin> joins = joinStatus != null
+                ? meetingJoinRepository.findByMeetingIdAndJoinStatus(meetingId, joinStatus, pageable)
+                : meetingJoinRepository.findByMeetingId(meetingId, pageable);
 
-        return joins.stream().map(MeetingJoinResult::from).toList();
-
-
+        // 엔티티 Page를 결과 DTO Page로 변환
+        return joins.map(MeetingJoinResult::from);
     }
 
     // 가입 신청 처리
@@ -209,7 +211,7 @@ public class MeetingJoinService {
         RecruitStatus before = meeting.getRecruitStatus();
         LocalDateTime now = LocalDateTime.now();
         meeting.applyRecruitClosedIfPeriodEnded(now, RECRUIT_PERIOD);
-        if(before != meeting.getRecruitStatus()) {
+        if (before != meeting.getRecruitStatus()) {
             meetingRepository.save(meeting);
         }
     }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingQueryService.java
@@ -6,9 +6,10 @@ import com.pagely.meetingservice.meeting.application.dto.result.MeetingSummaryRe
 import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 // 조회 전용 서비스
@@ -19,11 +20,9 @@ public class MeetingQueryService {
     private final MeetingRepository meetingRepository;
 
     // 전체 모임 조회
-    public List<MeetingSummaryResult> getMeetings() {
-        return meetingRepository.findAll()
-                .stream()
-                .map(MeetingSummaryResult::from)
-                .toList();
+    public Page<MeetingSummaryResult> getMeetings(Pageable pageable) {
+        return meetingRepository.findAll(pageable)
+                .map(MeetingSummaryResult::from);
     }
 
     // 모임 상세 조회

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleQueryService.java
@@ -7,9 +7,10 @@ import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCo
 import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingScheduleRepository;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,17 +23,15 @@ public class MeetingScheduleQueryService {
     private final MeetingRepository meetingRepository;
     private final MeetingScheduleRepository meetingScheduleRepository;
 
-    // 모임 일정 목록 조회
-    public List<MeetingScheduleResult> getSchedules(UUID meetingId) {
+    // 모임 일정 목록 조회 - 페이징 처리
+    public Page<MeetingScheduleResult> getSchedules(UUID meetingId, Pageable pageable) {
         // 요청한 모임이 실제 존재하는지 확인
         validateMeetingExists(meetingId);
 
-        // 삭제되지 않은 일정만 회차 번호 오름차순으로 조회
-        // 사용자에게는 유효한 일정 목록만 노출
-        return meetingScheduleRepository.findByMeetingIdAndDeletedAtIsNullOrderByScheduleNumberAsc(meetingId)
-                .stream()
-                .map(MeetingScheduleResult::from)
-                .toList();
+        // 삭제되지 않은 일정만 페이징 조회
+        // 정렬 기준은 Controller에서 Pageable 생성 시 전달한다.
+        return meetingScheduleRepository.findByMeetingIdAndDeletedAtIsNull(meetingId, pageable)
+                .map(MeetingScheduleResult::from);
     }
 
     // 모임 일정 상세 조회
@@ -41,21 +40,17 @@ public class MeetingScheduleQueryService {
         validateMeetingExists(meetingId);
 
         // 요청한 일정이 해당 모임에 속해 있고 삭제되지 않은 일정인지 확인
-        // 다른 모임의 일정 조회 및 삭제된 일정 조회를 방지
         MeetingSchedule schedule = meetingScheduleRepository.findByIdAndMeetingIdAndDeletedAtIsNull(
                         scheduleId,
                         meetingId
                 )
                 .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
-        // 조회된 일정 엔티티를 응답용 결과 DTO로 변환
         return MeetingScheduleResult.from(schedule);
     }
 
     // 모임 존재 여부 검증
     private void validateMeetingExists(UUID meetingId) {
-        // 일정 조회 전에 상위 리소스인 모임이 존재하는지 먼저 검증
-        // 존재하지 않는 모임에 대한 일정 조회 요청을 명확한 예외로 처리
         meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
     }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingAttendanceRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingAttendanceRepository.java
@@ -5,6 +5,8 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 // 출석 저장/조회 인터페이스
 public interface MeetingAttendanceRepository {
@@ -18,13 +20,19 @@ public interface MeetingAttendanceRepository {
     // 일정 + 유저 기준 출석 조회
     Optional<MeetingAttendance> findByScheduleIdAndUserId(UUID scheduleId, UUID userId);
 
-    // 특정 일정의 출석부 조회
+    // 특정 일정의 출석부 조회 - 페이징 처리
+    Page<MeetingAttendance> findByScheduleId(UUID scheduleId, Pageable pageable);
+
+    // 특정 일정의 출석부 조회 - 통계 계산용 전체 조회
     List<MeetingAttendance> findByScheduleId(UUID scheduleId);
 
     // 특정 일정의 상태별 출석 조회
     List<MeetingAttendance> findByScheduleIdAndStatus(UUID scheduleId, AttendanceStatus status);
 
-    // 특정 모임에서 내 출석 목록 조회
+    // 특정 모임에서 내 출석 목록 조회 - 페이징 처리
+    Page<MeetingAttendance> findByMeetingIdAndUserId(UUID meetingId, UUID userId, Pageable pageable);
+
+    // 특정 모임에서 내 출석 목록 조회 - 통계 계산용 전체 조회
     List<MeetingAttendance> findByMeetingIdAndUserId(UUID meetingId, UUID userId);
 
     // 특정 일정에 이미 출석 등록했는지 확인

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingJoinRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingJoinRepository.java
@@ -2,9 +2,10 @@ package com.pagely.meetingservice.meeting.domain.repository;
 
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 // 모임 가입 신청 저장/조회 인터페이스
 public interface MeetingJoinRepository {
@@ -15,16 +16,19 @@ public interface MeetingJoinRepository {
     // ID로 가입 신청 조회
     Optional<MeetingJoin> findById(UUID joinId);
 
-    // 특정 모임의 전체 가입 신청 조회
-    List<MeetingJoin> findByMeetingId(UUID meetingId);
+    // 특정 모임의 전체 가입 신청 조회 - 페이징 처리
+    Page<MeetingJoin> findByMeetingId(UUID meetingId, Pageable pageable);
 
-    // 특정 모임의 상태별 가입 신청 조회
-    List<MeetingJoin> findByMeetingIdAndJoinStatus(UUID meetingId, MeetingJoinStatus joinStatus);
+    // 특정 모임의 상태별 가입 신청 조회 - 페이징 처리
+    Page<MeetingJoin> findByMeetingIdAndJoinStatus(
+            UUID meetingId,
+            MeetingJoinStatus joinStatus,
+            Pageable pageable
+    );
 
     // 특정 모임 + 특정 유저의 신청 조회
     Optional<MeetingJoin> findByMeetingIdAndRecruitUserId(UUID meetingId, UUID recruitUserId);
 
     // 이미 가입 신청했는지 확인
     boolean existsByMeetingIdAndRecruitUserId(UUID meetingId, UUID recruitUserId);
-
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingRepository.java
@@ -4,6 +4,8 @@ import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 // 모임 저장/조회 인터페이스
 public interface MeetingRepository {
@@ -14,13 +16,13 @@ public interface MeetingRepository {
     // ID로 모임 조회
     Optional<Meeting> findById(UUID meetingId);
 
-    // 전체 모임 조회
-    List<Meeting> findAll();
+    // 전체 모임 조회 - 페이징
+    Page<Meeting> findAll(Pageable pageable);
 
     // 모임장 기준 모임 조회
     List<Meeting> findByHostId(UUID hostId);
 
     // 모임 존재 여부 확인
     boolean existsById(UUID meetingId);
-    
+
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingScheduleRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingScheduleRepository.java
@@ -5,6 +5,8 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 // 모임 일정 저장/조회 인터페이스
 public interface MeetingScheduleRepository {
@@ -19,7 +21,7 @@ public interface MeetingScheduleRepository {
     List<MeetingSchedule> findByMeetingId(UUID meetingId);
 
     // 특정 모임의 삭제되지 않은 일정 목록 조회
-    List<MeetingSchedule> findByMeetingIdAndDeletedAtIsNullOrderByScheduleNumberAsc(UUID meetingId);
+    Page<MeetingSchedule> findByMeetingIdAndDeletedAtIsNull(UUID meetingId, Pageable pageable);
 
     // 특정 모임의 삭제되지 않은 일정 상세 조회
     Optional<MeetingSchedule> findByIdAndMeetingIdAndDeletedAtIsNull(UUID scheduleId, UUID meetingId);

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingAttendanceRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingAttendanceRepository.java
@@ -5,6 +5,8 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 // 모임 일정 참석 JPA Repository
@@ -13,7 +15,10 @@ public interface JpaMeetingAttendanceRepository extends JpaRepository<MeetingAtt
     // 일정 + 유저 기준 참석 조회
     Optional<MeetingAttendance> findByScheduleIdAndUserIdAndDeletedAtIsNull(UUID scheduleId, UUID userId);
 
-    // 특정 일정의 참석 목록 조회
+    // 특정 일정의 참석 목록 조회 - 페이징 처리
+    Page<MeetingAttendance> findAllByScheduleIdAndDeletedAtIsNull(UUID scheduleId, Pageable pageable);
+
+    // 특정 일정의 참석 목록 조회 - 통계 계산용 전체 조회
     List<MeetingAttendance> findAllByScheduleIdAndDeletedAtIsNull(UUID scheduleId);
 
     // 특정 일정의 상태별 참석 목록 조회
@@ -22,7 +27,14 @@ public interface JpaMeetingAttendanceRepository extends JpaRepository<MeetingAtt
             AttendanceStatus status
     );
 
-    // 특정 모임에서 특정 유저의 참석 목록 조회
+    // 특정 모임에서 특정 유저의 참석 목록 조회 - 페이징 처리
+    Page<MeetingAttendance> findAllByMeetingIdAndUserIdAndDeletedAtIsNull(
+            UUID meetingId,
+            UUID userId,
+            Pageable pageable
+    );
+
+    // 특정 모임에서 특정 유저의 참석 목록 조회 - 통계 계산용 전체 조회
     List<MeetingAttendance> findAllByMeetingIdAndUserIdAndDeletedAtIsNull(UUID meetingId, UUID userId);
 
     // 특정 일정에 이미 참석 등록했는지 확인

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingJoinRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingJoinRepository.java
@@ -1,22 +1,29 @@
 package com.pagely.meetingservice.meeting.infrastructure.persistence;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
+// 모임 가입 신청 JPA Repository
 public interface JpaMeetingJoinRepository extends JpaRepository<MeetingJoin, UUID> {
-    
-    List<MeetingJoin> findByMeetingId(UUID meetingId); // 모임 ID 기준 목록 조회
 
-    List<MeetingJoin> findByMeetingIdAndJoinStatus(UUID meetingId, MeetingJoinStatus joinStatus); // 모임+상태 기준 목록 조회
+    // 모임 ID 기준 가입 신청 목록 조회 - 페이징 처리
+    Page<MeetingJoin> findByMeetingId(UUID meetingId, Pageable pageable);
 
-    Optional<MeetingJoin> findByMeetingIdAndRecruitUserId(UUID meetingId, UUID recruitUserId); // 모임+유저 기준 단건 조회
+    // 모임 ID + 가입 신청 상태 기준 목록 조회 - 페이징 처리
+    Page<MeetingJoin> findByMeetingIdAndJoinStatus(
+            UUID meetingId,
+            MeetingJoinStatus joinStatus,
+            Pageable pageable
+    );
 
-    boolean existsByMeetingIdAndRecruitUserId(UUID meetingId, UUID recruitUserId); // 모임+유저 기준 존재 여부 조회
-    
+    // 모임 ID + 유저 ID 기준 단건 조회
+    Optional<MeetingJoin> findByMeetingIdAndRecruitUserId(UUID meetingId, UUID recruitUserId);
+
+    // 모임 ID + 유저 ID 기준 존재 여부 조회
+    boolean existsByMeetingIdAndRecruitUserId(UUID meetingId, UUID recruitUserId);
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingRepository.java
@@ -4,13 +4,15 @@ import com.pagely.meetingservice.meeting.domain.model.Meeting;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 // Spring Data JPA 전용 레포지토리
 public interface JpaMeetingRepository extends JpaRepository<Meeting, UUID> {
 
-    // 삭제되지 않은 모임 전체 조회
-    List<Meeting> findByDeletedAtIsNull();
+    // 삭제되지 않은 모임 전체 조회 - 페이징
+    Page<Meeting> findByDeletedAtIsNull(Pageable pageable);
 
     // ID로 삭제되지 않은 모임 조회
     Optional<Meeting> findByIdAndDeletedAtIsNull(UUID meetingId);

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingScheduleRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingScheduleRepository.java
@@ -5,6 +5,8 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 // 모임 일정 JPA Repository
@@ -13,8 +15,8 @@ public interface JpaMeetingScheduleRepository extends JpaRepository<MeetingSched
     // 특정 모임의 일정 목록 조회
     List<MeetingSchedule> findByMeetingId(UUID meetingId);
 
-    // 특정 모임의 삭제되지 않은 일정 목록 조회
-    List<MeetingSchedule> findByMeetingIdAndDeletedAtIsNullOrderByScheduleNumberAsc(UUID meetingId);
+    // 특정 모임의 삭제되지 않은 일정 목록 조회 - 페이징 처리
+    Page<MeetingSchedule> findByMeetingIdAndDeletedAtIsNull(UUID meetingId, Pageable pageable);
 
     // 특정 모임의 삭제되지 않은 일정 상세 조회
     Optional<MeetingSchedule> findByIdAndMeetingIdAndDeletedAtIsNull(UUID scheduleId, UUID meetingId);

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingAttendanceRepositoryAdapter.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingAttendanceRepositoryAdapter.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 // 모임 일정 참석 Repository 구현체
@@ -37,12 +39,6 @@ public class MeetingAttendanceRepositoryAdapter implements MeetingAttendanceRepo
         );
     }
 
-    // 특정 일정의 출석부 조회
-    @Override
-    public List<MeetingAttendance> findByScheduleId(UUID scheduleId) {
-        return jpaMeetingAttendanceRepository.findAllByScheduleIdAndDeletedAtIsNull(scheduleId);
-    }
-
     // 특정 일정의 상태별 출석 조회
     @Override
     public List<MeetingAttendance> findByScheduleIdAndStatus(UUID scheduleId, AttendanceStatus status) {
@@ -52,20 +48,49 @@ public class MeetingAttendanceRepositoryAdapter implements MeetingAttendanceRepo
         );
     }
 
-    // 특정 모임에서 내 출석 목록 조회
-    @Override
-    public List<MeetingAttendance> findByMeetingIdAndUserId(UUID meetingId, UUID userId) {
-        return jpaMeetingAttendanceRepository.findAllByMeetingIdAndUserIdAndDeletedAtIsNull(
-                meetingId,
-                userId
-        );
-    }
-
     // 특정 일정에 이미 출석 등록했는지 확인
     @Override
     public boolean existsByScheduleIdAndUserId(UUID scheduleId, UUID userId) {
         return jpaMeetingAttendanceRepository.existsByScheduleIdAndUserIdAndDeletedAtIsNull(
                 scheduleId,
+                userId
+        );
+    }
+
+    // 특정 일정의 출석부 조회 - 페이징 처리
+    @Override
+    public Page<MeetingAttendance> findByScheduleId(UUID scheduleId, Pageable pageable) {
+        return jpaMeetingAttendanceRepository.findAllByScheduleIdAndDeletedAtIsNull(
+                scheduleId,
+                pageable
+        );
+    }
+
+    // 특정 일정의 출석부 조회 - 통계 계산용 전체 조회
+    @Override
+    public List<MeetingAttendance> findByScheduleId(UUID scheduleId) {
+        return jpaMeetingAttendanceRepository.findAllByScheduleIdAndDeletedAtIsNull(scheduleId);
+    }
+
+    // 특정 모임에서 내 출석 목록 조회 - 페이징 처리
+    @Override
+    public Page<MeetingAttendance> findByMeetingIdAndUserId(
+            UUID meetingId,
+            UUID userId,
+            Pageable pageable
+    ) {
+        return jpaMeetingAttendanceRepository.findAllByMeetingIdAndUserIdAndDeletedAtIsNull(
+                meetingId,
+                userId,
+                pageable
+        );
+    }
+
+    // 특정 모임에서 내 출석 목록 조회 - 통계 계산용 전체 조회
+    @Override
+    public List<MeetingAttendance> findByMeetingIdAndUserId(UUID meetingId, UUID userId) {
+        return jpaMeetingAttendanceRepository.findAllByMeetingIdAndUserIdAndDeletedAtIsNull(
+                meetingId,
                 userId
         );
     }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingJoinRepositoryAdapter.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingJoinRepositoryAdapter.java
@@ -3,9 +3,10 @@ package com.pagely.meetingservice.meeting.infrastructure.persistence;
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
 import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingJoinRepository;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -28,15 +29,24 @@ public class MeetingJoinRepositoryAdapter implements MeetingJoinRepository {
         return jpaMeetingJoinRepository.findById(joinId);
     }
 
+    // 모임 기준 가입 신청 목록 조회 - 페이징 처리
     @Override
-    public List<MeetingJoin> findByMeetingId(UUID meetingId) { // 모임 기준 목록 조회 메서드
-        return jpaMeetingJoinRepository.findByMeetingId(meetingId);
+    public Page<MeetingJoin> findByMeetingId(UUID meetingId, Pageable pageable) {
+        return jpaMeetingJoinRepository.findByMeetingId(meetingId, pageable);
     }
 
+    // 모임 + 상태 기준 가입 신청 목록 조회 - 페이징 처리
     @Override
-    public List<MeetingJoin> findByMeetingIdAndJoinStatus(UUID meetingId,
-                                                          MeetingJoinStatus joinStatus) { // 모임+상태 목록 조회 메서드
-        return jpaMeetingJoinRepository.findByMeetingIdAndJoinStatus(meetingId, joinStatus);
+    public Page<MeetingJoin> findByMeetingIdAndJoinStatus(
+            UUID meetingId,
+            MeetingJoinStatus joinStatus,
+            Pageable pageable
+    ) {
+        return jpaMeetingJoinRepository.findByMeetingIdAndJoinStatus(
+                meetingId,
+                joinStatus,
+                pageable
+        );
     }
 
     @Override

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingRepositoryAdapter.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingRepositoryAdapter.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 // 도메인 Repository 인터페이스의 실제 JPA 구현체
@@ -29,8 +31,8 @@ public class MeetingRepositoryAdapter implements MeetingRepository {
 
     // 삭제되지 않은 전체 모임 조회
     @Override
-    public List<Meeting> findAll() {
-        return jpaMeetingRepository.findByDeletedAtIsNull();
+    public Page<Meeting> findAll(Pageable pageable) {
+        return jpaMeetingRepository.findByDeletedAtIsNull(pageable);
     }
 
     // 모임장 기준 삭제되지 않은 모임 조회

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingScheduleRepositoryAdapter.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingScheduleRepositoryAdapter.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 // 모임 일정 Repository 구현체
@@ -58,10 +60,10 @@ public class MeetingScheduleRepositoryAdapter implements MeetingScheduleReposito
         return jpaMeetingScheduleRepository.existsByMeetingIdAndScheduleNumber(meetingId, scheduleNumber);
     }
 
-    // 특정 모임의 삭제되지 않은 일정 목록 조회
+    // 특정 모임의 삭제되지 않은 일정 목록 조회 - 페이징 처리
     @Override
-    public List<MeetingSchedule> findByMeetingIdAndDeletedAtIsNullOrderByScheduleNumberAsc(UUID meetingId) {
-        return jpaMeetingScheduleRepository.findByMeetingIdAndDeletedAtIsNullOrderByScheduleNumberAsc(meetingId);
+    public Page<MeetingSchedule> findByMeetingIdAndDeletedAtIsNull(UUID meetingId, Pageable pageable) {
+        return jpaMeetingScheduleRepository.findByMeetingIdAndDeletedAtIsNull(meetingId, pageable);
     }
 
     // 특정 모임의 삭제되지 않은 일정 상세 조회

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -1,5 +1,7 @@
 package com.pagely.meetingservice.meeting.presentation.controller;
 
+import com.pagely.common.pagination.PageRequest;
+import com.pagely.common.pagination.PageResponse;
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateAttendanceStatusCommand;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateScheduleStatusCommand;
@@ -32,6 +34,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -72,12 +75,12 @@ public class MeetingController {
 
     // 모임 전체 조회
     @GetMapping
-    public List<MeetingSummaryResponse> getMeetings() {
-        List<MeetingSummaryResult> results = meetingQueryService.getMeetings();
+    public PageResponse<MeetingSummaryResponse> getMeetings(PageRequest pageRequest) {
+        Page<MeetingSummaryResult> results = meetingQueryService.getMeetings(
+                pageRequest.toPageable()
+        );
 
-        return results.stream()
-                .map(MeetingSummaryResponse::from)
-                .toList();
+        return PageResponse.of(results, MeetingSummaryResponse::from);
     }
 
     // 모임 상세 조회
@@ -238,6 +241,7 @@ public class MeetingController {
 //                .map(MeetingAttendanceResponse::from)
 //                .toList();
 //    }
+
     // 출석부 조회 (Kafka 연결 전 임시 지각/결석 계산 로직 연결 - 이벤트 연결 후 수정 예정)
     @GetMapping("/{meetingId}/schedules/{scheduleId}/attendances")
     public MeetingAttendanceListResponse getScheduleAttendances(

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -161,14 +162,17 @@ public class MeetingController {
 
     // 모임 일정 목록 조회
     @GetMapping("/{meetingId}/schedules")
-    public List<MeetingScheduleResponse> getMeetingSchedules(
-            @PathVariable UUID meetingId
+    public PageResponse<MeetingScheduleResponse> getMeetingSchedules(
+            @PathVariable UUID meetingId,
+            PageRequest pageRequest
     ) {
-        List<MeetingScheduleResult> results = meetingScheduleQueryService.getSchedules(meetingId);
+        // 회차 번호 오름차순 기준으로 페이징 조회
+        Page<MeetingScheduleResult> results = meetingScheduleQueryService.getSchedules(
+                meetingId,
+                pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "scheduleNumber"))
+        );
 
-        return results.stream()
-                .map(MeetingScheduleResponse::from)
-                .toList();
+        return PageResponse.of(results, MeetingScheduleResponse::from);
     }
 
     // 모임 일정 상세 조회

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -24,14 +24,13 @@ import com.pagely.meetingservice.meeting.presentation.dto.request.CreateMeetingS
 import com.pagely.meetingservice.meeting.presentation.dto.request.JoinMeetingRequest;
 import com.pagely.meetingservice.meeting.presentation.dto.request.UpdateAttendanceStatusRequest;
 import com.pagely.meetingservice.meeting.presentation.dto.request.UpdateScheduleStatusRequest;
-import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingAttendanceListResponse;
+import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingAttendancePageResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingAttendanceResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingJoinResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingScheduleResponse;
 import com.pagely.meetingservice.meeting.presentation.dto.response.MeetingSummaryResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -67,14 +66,14 @@ public class MeetingController {
             @Valid @RequestBody CreateMeetingRequest req
     ) {
         MeetingResult result = meetingCommandService.createMeeting(
-                req.toCommand(req.hostId()) // DTO → Command 변환
+                req.toCommand(req.hostId())
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(MeetingResponse.from(result));
     }
 
-    // 모임 전체 조회
+    // 모임 전체 조회 - 페이징 처리
     @GetMapping
     public PageResponse<MeetingSummaryResponse> getMeetings(PageRequest pageRequest) {
         Page<MeetingSummaryResult> results = meetingQueryService.getMeetings(
@@ -105,22 +104,23 @@ public class MeetingController {
                 .body(MeetingJoinResponse.from(result));
     }
 
-    // 가입 신청 목록 조회
+    // 가입 신청 목록 조회 - 페이징 처리
     @GetMapping("/{meetingId}/join")
-    public List<MeetingJoinResponse> getMeetingJoinList(
+    public PageResponse<MeetingJoinResponse> getMeetingJoinList(
             @PathVariable UUID meetingId,
             @RequestParam UUID hostId,
-            @RequestParam(required = false) MeetingJoinStatus joinStatus
+            @RequestParam(required = false) MeetingJoinStatus joinStatus,
+            PageRequest pageRequest
     ) {
-        List<MeetingJoinResult> results = meetingJoinService.getMeetingJoinList(
+        // 최신 가입 신청이 먼저 보이도록 생성일 내림차순 정렬
+        Page<MeetingJoinResult> results = meetingJoinService.getMeetingJoinList(
                 meetingId,
                 hostId,
-                joinStatus
+                joinStatus,
+                pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"))
         );
 
-        return results.stream()
-                .map(MeetingJoinResponse::from)
-                .toList();
+        return PageResponse.of(results, MeetingJoinResponse::from);
     }
 
     // 모임 가입 승인
@@ -160,7 +160,7 @@ public class MeetingController {
                 .body(MeetingScheduleResponse.from(result));
     }
 
-    // 모임 일정 목록 조회
+    // 모임 일정 목록 조회 - 페이징 처리
     @GetMapping("/{meetingId}/schedules")
     public PageResponse<MeetingScheduleResponse> getMeetingSchedules(
             @PathVariable UUID meetingId,
@@ -182,7 +182,6 @@ public class MeetingController {
             @PathVariable UUID scheduleId
     ) {
         MeetingScheduleResult result = meetingScheduleQueryService.getSchedule(meetingId, scheduleId);
-
         return MeetingScheduleResponse.from(result);
     }
 
@@ -226,86 +225,57 @@ public class MeetingController {
         return ResponseEntity.ok(MeetingScheduleResponse.from(result));
     }
 
-    // 출석부 조회
-//    @GetMapping("/{meetingId}/schedules/{scheduleId}/attendances")
-//    public List<MeetingAttendanceResponse> getScheduleAttendances(
-//            @PathVariable UUID meetingId,
-//            @PathVariable UUID scheduleId
-//    ) {
-//        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID : 모임장)
-//        UUID userId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-//
-//        List<MeetingAttendanceResult> results = meetingAttendanceQueryService.getScheduleAttendances(
-//                meetingId,
-//                scheduleId,
-//                userId
-//        );
-//
-//        return results.stream()
-//                .map(MeetingAttendanceResponse::from)
-//                .toList();
-//    }
-
-    // 출석부 조회 (Kafka 연결 전 임시 지각/결석 계산 로직 연결 - 이벤트 연결 후 수정 예정)
+    // 특정 일정 출석부 조회 - 페이징 처리
     @GetMapping("/{meetingId}/schedules/{scheduleId}/attendances")
-    public MeetingAttendanceListResponse getScheduleAttendances(
+    public MeetingAttendancePageResponse getScheduleAttendances(
             @PathVariable UUID meetingId,
-            @PathVariable UUID scheduleId
+            @PathVariable UUID scheduleId,
+            PageRequest pageRequest
     ) {
-        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID : 모임장)
+        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID: 모임장)
         UUID userId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-        List<MeetingAttendanceResult> results = meetingAttendanceQueryService.getScheduleAttendances(
+        // 출석 목록은 페이징 처리
+        Page<MeetingAttendanceResult> results = meetingAttendanceQueryService.getScheduleAttendances(
                 meetingId,
                 scheduleId,
-                userId
+                userId,
+                pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "createdAt"))
         );
 
+        // 출석 통계는 전체 출석 기록 기준으로 계산
         AttendanceStatisticsResult statistics = meetingAttendanceQueryService.getScheduleAttendanceStatistics(
                 meetingId,
                 scheduleId,
                 userId
         );
 
-        return MeetingAttendanceListResponse.from(results, statistics);
+        return MeetingAttendancePageResponse.from(results, statistics);
     }
 
-    // 내 출석부 조회
-//    @GetMapping("/{meetingId}/attendances/me")
-//    public List<MeetingAttendanceResponse> getMyAttendances(
-//            @PathVariable UUID meetingId
-//    ) {
-//        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID : 모임원)
-//        UUID userId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
-//
-//        List<MeetingAttendanceResult> results = meetingAttendanceQueryService.getMyAttendances(
-//                meetingId,
-//                userId
-//        );
-//
-//        return results.stream()
-//                .map(MeetingAttendanceResponse::from)
-//                .toList();
-//    }
-    // 내 출석부 조회 (Kafka 연결 전 임시 지각/결석 계산 로직 연결 - 이벤트 연결 후 수정 예정)
+    // 내 출석부 조회 - 페이징 처리
     @GetMapping("/{meetingId}/attendances/me")
-    public MeetingAttendanceListResponse getMyAttendances(
-            @PathVariable UUID meetingId
+    public MeetingAttendancePageResponse getMyAttendances(
+            @PathVariable UUID meetingId,
+            PageRequest pageRequest
     ) {
-        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID : 모임원)
+        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID: 모임원)
         UUID userId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
 
-        List<MeetingAttendanceResult> results = meetingAttendanceQueryService.getMyAttendances(
+        // 내 출석 이력은 페이징 처리
+        Page<MeetingAttendanceResult> results = meetingAttendanceQueryService.getMyAttendances(
                 meetingId,
-                userId
+                userId,
+                pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "createdAt"))
         );
 
+        // 내 출석 통계는 전체 출석 이력 기준으로 계산
         AttendanceStatisticsResult statistics = meetingAttendanceQueryService.getMyAttendanceStatistics(
                 meetingId,
                 userId
         );
 
-        return MeetingAttendanceListResponse.from(results, statistics);
+        return MeetingAttendancePageResponse.from(results, statistics);
     }
 
     // 출석 상태 변경

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingAttendancePageResponse.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/MeetingAttendancePageResponse.java
@@ -1,0 +1,24 @@
+package com.pagely.meetingservice.meeting.presentation.dto.response;
+
+import com.pagely.common.pagination.PageResponse;
+import com.pagely.meetingservice.meeting.application.dto.result.AttendanceStatisticsResult;
+import com.pagely.meetingservice.meeting.application.dto.result.MeetingAttendanceResult;
+import org.springframework.data.domain.Page;
+
+// 출석부 페이징 목록 + 출석 통계 응답 DTO
+public record MeetingAttendancePageResponse(
+        PageResponse<MeetingAttendanceResponse> attendances,
+        AttendanceStatisticsResult statistics
+) {
+
+    // 출석 결과 Page와 통계 결과를 응답 DTO로 변환
+    public static MeetingAttendancePageResponse from(
+            Page<MeetingAttendanceResult> attendances,
+            AttendanceStatisticsResult statistics
+    ) {
+        return new MeetingAttendancePageResponse(
+                PageResponse.of(attendances, MeetingAttendanceResponse::from),
+                statistics
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

조회 API 전반에 페이징 처리를 적용하여 대용량 데이터 대응 및 API 응답 구조를 표준화

* 모임, 일정, 가입 신청, 출석 조회 API에 Page 기반 페이징 적용
* 공통 PageRequest / PageResponse 구조 활용
* 출석 조회 API는 목록(Page) + 통계(전체) 분리 구조로 개선
* 정렬 기준 명시 적용 (createdAt, scheduleNumber 등)

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #41 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #41 

📌 적용 범위

* 모임 전체 조회 → PageResponse 적용
* 모임 일정 목록 조회 → PageResponse 적용
* 가입 신청 목록 조회 → PageResponse 적용
* 특정 일정 출석부 조회 → Page + 통계 구조 적용
* 내 출석부 조회 → Page + 통계 구조 적용

GET /api/v1/meetings?page=0&size=10
GET /api/v1/meetings/{meetingId}/schedules?page=0&size=10
GET /api/v1/meetings/{meetingId}/join?page=0&size=10
GET /api/v1/meetings/{meetingId}/schedules/{scheduleId}/attendances?page=0&size=10
GET /api/v1/meetings/{meetingId}/attendances/me?page=0&size=10

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1273" height="904" alt="스크린샷 2026-04-29 오전 3 41 00" src="https://github.com/user-attachments/assets/eb732fbf-ae2e-4347-9e0f-4839888afb13" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 회의 목록, 참석자 목록, 일정, 참석 기록 조회에 페이지네이션 기능 추가
  * 대규모 데이터 조회 시 개선된 성능 및 로딩 시간 단축
  * 페이지 요청 파라미터를 통한 유연한 데이터 페이징 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->