### PR TITLE
Feat/45 모임 서비스 BaseEntity 적용

### DIFF
--- a/src/main/java/com/pagely/meetingservice/MeetingserviceApplication.java
+++ b/src/main/java/com/pagely/meetingservice/MeetingserviceApplication.java
@@ -2,9 +2,8 @@ package com.pagely.meetingservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
+
 @SpringBootApplication
 public class MeetingserviceApplication {
 

--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
@@ -39,7 +39,9 @@ public record CreateMeetingCommand(
                 readingLevel,
                 ruleMemo,
                 recruitRate,
-                Boolean.TRUE.equals(freePaid)
+                Boolean.TRUE.equals(freePaid),
+                now,
+                createdBy
         );
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/dto/command/CreateMeetingCommand.java
@@ -39,9 +39,7 @@ public record CreateMeetingCommand(
                 readingLevel,
                 ruleMemo,
                 recruitRate,
-                Boolean.TRUE.equals(freePaid),
-                now,
-                createdBy
+                Boolean.TRUE.equals(freePaid)
         );
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinListSortPolicy.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinListSortPolicy.java
@@ -1,24 +1,24 @@
-package com.pagely.meetingservice.meeting.application.service;
+// package com.pagely.meetingservice.meeting.application.service;
 
-import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
-import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import org.springframework.stereotype.Component;
+// import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
+// import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
+// import java.time.LocalDateTime;
+// import java.util.Comparator;
+// import java.util.List;
+// import org.springframework.stereotype.Component;
 
-@Component
-public class MeetingJoinListSortPolicy {
+// @Component
+// public class MeetingJoinListSortPolicy {
 
-    public void sortForHostJoinList(List<MeetingJoin> joins) {
-        joins.sort(defaultHostListComparator());
-    }
+//     public void sortForHostJoinList(List<MeetingJoin> joins) {
+//         joins.sort(defaultHostListComparator());
+//     }
 
-    private Comparator<MeetingJoin> defaultHostListComparator() {
-        Comparator<LocalDateTime> createdAtDesc =
-                Comparator.nullsLast(Comparator.<LocalDateTime>naturalOrder()).reversed();
-        return Comparator
-                .comparing((MeetingJoin j) -> j.getJoinStatus() != MeetingJoinStatus.PENDING)
-                .thenComparing(MeetingJoin::getCreatedAt, createdAtDesc);
-    }
-}
+//     private Comparator<MeetingJoin> defaultHostListComparator() {
+//         Comparator<LocalDateTime> createdAtDesc =
+//                 Comparator.nullsLast(Comparator.<LocalDateTime>naturalOrder()).reversed();
+//         return Comparator
+//                 .comparing((MeetingJoin j) -> j.getJoinStatus() != MeetingJoinStatus.PENDING)
+//                 .thenComparing(MeetingJoin::getCreatedAt, createdAtDesc);
+//     }
+// }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
@@ -31,7 +31,6 @@ public class MeetingJoinService {
 
     private final MeetingJoinRepository meetingJoinRepository;
     private final MeetingRepository meetingRepository;
-    private final MeetingJoinListSortPolicy meetingJoinListSortPolicy;
     private final MeetingMemberRepository meetingMemberRepository;
 
     private static final UUID RECRUIT_PERIOD = UUID.fromString("00000000-0000-0000-0000-000000000000");
@@ -39,11 +38,9 @@ public class MeetingJoinService {
     // 생성자
     public MeetingJoinService(MeetingJoinRepository meetingJoinRepository,
                               MeetingRepository meetingRepository,
-                              MeetingJoinListSortPolicy meetingJoinListSortPolicy,
                               MeetingMemberRepository meetingMemberRepository) {
         this.meetingJoinRepository = meetingJoinRepository;
         this.meetingRepository = meetingRepository;
-        this.meetingJoinListSortPolicy = meetingJoinListSortPolicy;
         this.meetingMemberRepository = meetingMemberRepository;
     }
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -105,7 +105,9 @@ public class Meeting extends BaseEntity{
             ReadingLevel readingLevel,
             String ruleMemo,
             RecruitRate recruitRate,
-            boolean freePaid
+            boolean freePaid,
+            LocalDateTime createdAt,
+            UUID createdBy
     ) {
         if (recruitMax <= 0) {
             throw new BusinessException(MeetingErrorCode.INVALID_RECRUIT_MAX);
@@ -130,6 +132,8 @@ public class Meeting extends BaseEntity{
         meeting.ruleMemo = ruleMemo;
         meeting.recruitRate = recruitRate;
         meeting.freePaid = freePaid;
+        meeting.createdAt = createdAt;
+        meeting.createdBy = createdBy;
         return meeting;
     }
 
@@ -138,7 +142,6 @@ public class Meeting extends BaseEntity{
         this.updatedBy = updatedBy;
         this.updatedAt = LocalDateTime.now();
     }
-
         // 모집 마감 시간이 지났으면 RECRUITING → CLOSED 로 전이
     public void applyRecruitClosedIfPeriodEnded(LocalDateTime now, UUID updatedBy) {
         if (this.recruitStatus != RecruitStatus.RECRUITING) {
@@ -208,14 +211,6 @@ public class Meeting extends BaseEntity{
 
     public boolean isFreePaid() {
         return freePaid;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public UUID getCreatedBy() {
-        return createdBy;
     }
 
     public boolean canViewJoinApplications(UUID userId) {

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/Meeting.java
@@ -1,5 +1,6 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.entity.BaseEntity;
 import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
 import jakarta.persistence.Column;
@@ -10,14 +11,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-@Getter
+
 @Entity
 @Table(name = "p_meeting")
-public class Meeting {
+public class Meeting extends BaseEntity{
 
     @Id
     private UUID id;
@@ -88,30 +88,6 @@ public class Meeting {
     @Column(name = "free_paid", nullable = false)
     private boolean freePaid;
 
-    // 생성 시각
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    // 생성자 ID
-    @Column(name = "created_by", nullable = false, updatable = false)
-    private UUID createdBy;
-
-    // 수정 시각
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    // 수정자 ID
-    @Column(name = "updated_by")
-    private UUID updatedBy;
-
-    // 삭제 시각
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    // 삭제자 ID
-    @Column(name = "deleted_by")
-    private UUID deletedBy;
-
     protected Meeting() {
     }
 
@@ -129,9 +105,7 @@ public class Meeting {
             ReadingLevel readingLevel,
             String ruleMemo,
             RecruitRate recruitRate,
-            boolean freePaid,
-            LocalDateTime createdAt,
-            UUID createdBy
+            boolean freePaid
     ) {
         if (recruitMax <= 0) {
             throw new BusinessException(MeetingErrorCode.INVALID_RECRUIT_MAX);
@@ -156,8 +130,6 @@ public class Meeting {
         meeting.ruleMemo = ruleMemo;
         meeting.recruitRate = recruitRate;
         meeting.freePaid = freePaid;
-        meeting.createdAt = createdAt;
-        meeting.createdBy = createdBy;
         return meeting;
     }
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingAttendance.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingAttendance.java
@@ -48,30 +48,6 @@ public class MeetingAttendance extends BaseEntity {
     @Column(name = "note", length = 255)
     private String note;
 
-    // 생성일시
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    // 생성자 ID
-    @Column(name = "created_by", nullable = false, updatable = false)
-    private UUID createdBy;
-
-    // 수정일시
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    // 수정자 ID
-    @Column(name = "updated_by")
-    private UUID updatedBy;
-
-    // 삭제일시
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    // 삭제자 ID
-    @Column(name = "deleted_by")
-    private UUID deletedBy;
-
     protected MeetingAttendance() {
     }
 
@@ -191,11 +167,4 @@ public class MeetingAttendance extends BaseEntity {
         return note;
     }
 
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public UUID getCreatedBy() {
-        return createdBy;
-    }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingAttendance.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingAttendance.java
@@ -1,5 +1,6 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.entity.BaseEntity;
 import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingAttendanceErrorCode;
 import jakarta.persistence.Column;
@@ -16,7 +17,7 @@ import org.hibernate.type.SqlTypes;
 // 모임 일정 참석 엔티티
 @Entity
 @Table(name = "p_meeting_attendance")
-public class MeetingAttendance {
+public class MeetingAttendance extends BaseEntity {
 
     @Id
     private UUID id;

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
@@ -1,5 +1,6 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.entity.BaseEntity;
 import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingJoinErrorCode;
 import jakarta.persistence.Column;
@@ -15,7 +16,7 @@ import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_meeting_recruit")
-public class MeetingJoin {
+public class MeetingJoin extends BaseEntity {
 
     @Id
     private UUID id;

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingJoin.java
@@ -43,25 +43,6 @@ public class MeetingJoin extends BaseEntity {
     @Column(name = "reject_reason")
     private String rejectReason;
 
-    // 공통 감사 컬럼
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "created_by", nullable = false, updatable = false)
-    private UUID createdBy;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    @Column(name = "updated_by")
-    private UUID updatedBy;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    @Column(name = "deleted_by")
-    private UUID deletedBy;
-
     protected MeetingJoin() {
     }
 
@@ -129,12 +110,5 @@ public class MeetingJoin extends BaseEntity {
     public String getRejectReason() {
         return rejectReason;
     }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public UUID getCreatedBy() {
-        return createdBy;
-    }
+    
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
@@ -53,30 +53,6 @@ public class MeetingMember extends BaseEntity {
     @Column(name = "late_count", nullable = false)
     private int lateCount;
 
-    // 생성 시각
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    // 생성자 ID
-    @Column(name = "created_by", nullable = false, updatable = false)
-    private UUID createdBy;
-
-    // 수정 시각
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    // 수정자 ID
-    @Column(name = "updated_by")
-    private UUID updatedBy;
-
-    // 삭제 시각
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    // 삭제자 ID
-    @Column(name = "deleted_by")
-    private UUID deletedBy;
-
     protected MeetingMember() {
     }
 
@@ -185,14 +161,6 @@ public class MeetingMember extends BaseEntity {
 
     public int getWarningCount() {
         return warningCount;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public UUID getCreatedBy() {
-        return createdBy;
     }
 
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
@@ -11,10 +11,12 @@ import java.util.UUID;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import com.pagely.common.entity.BaseEntity;
+
 // 모임원 엔티티
 @Entity
 @Table(name = "p_meeting_members")
-public class MeetingMember {
+public class MeetingMember extends BaseEntity {
 
     @Id
     private UUID id;

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingSchedule.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingSchedule.java
@@ -1,5 +1,6 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.entity.BaseEntity;
 import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
 import jakarta.persistence.Column;
@@ -18,7 +19,7 @@ import org.hibernate.type.SqlTypes;
 @Getter
 @Entity
 @Table(name = "p_meeting_schedules")
-public class MeetingSchedule {
+public class MeetingSchedule extends BaseEntity {
 
     @Id
     private UUID id;
@@ -48,30 +49,6 @@ public class MeetingSchedule {
     // 토론 메모
     @Column(name = "discussion_note")
     private String discussionNote;
-
-    // 생성 시각
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    // 생성자 ID
-    @Column(name = "created_by", nullable = false, updatable = false)
-    private UUID createdBy;
-
-    // 수정 시각
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
-    // 수정자 ID
-    @Column(name = "updated_by")
-    private UUID updatedBy;
-
-    // 삭제 시각
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    // 삭제자 ID
-    @Column(name = "deleted_by")
-    private UUID deletedBy;
 
     protected MeetingSchedule() {
     }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 모임 도메인 JPA 엔티티를 BaseEntity 기준으로 통합
- 자식 엔티티에 중복으로 선언되어 있던 감사 컬럼 정리
- MeetingJoinService에서 사용되지 않던 의존성(MeetingJoinListSortPolicy)을 제거
- MeetingserviceApplication의 @EnableJpaAuditing는 제거하고, common 모듈의 JpaAuditingAutoConfiguration만 사용하도록 중복 제거

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #45  \

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 감시(audit) 기능을 공통 기본 엔티티로 통합하여 코드 중복을 제거했습니다.
  * 여러 도메인 모델이 이제 공유 기본 클래스로부터 감시 필드를 상속받습니다.

* **Bug Fixes**
  * 회의 참여자 정렬 기능을 비활성화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->