### PR TITLE
Feat/49 인증 컨텍스트 적용 (모임 생성/가입/승인)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation "com.pagely:common:1.0.2"
+    implementation "com.pagely:common:2.0.0"
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -66,7 +66,7 @@ public class MeetingController {
     @AuthRequired
     @PostMapping
     public ResponseEntity<MeetingResponse> createMeeting(
-        @CurrentUserId UUID currentUserId,
+            @CurrentUserId UUID currentUserId,
             @Valid @RequestBody CreateMeetingRequest req
     ) {
         MeetingResult result = meetingCommandService.createMeeting(

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -1,5 +1,7 @@
 package com.pagely.meetingservice.meeting.presentation.controller;
 
+import com.pagely.common.auth.annotation.AuthRequired;
+import com.pagely.common.auth.annotation.CurrentUserId;
 import com.pagely.common.pagination.PageRequest;
 import com.pagely.common.pagination.PageResponse;
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
@@ -61,12 +63,14 @@ public class MeetingController {
     private final MeetingAttendanceQueryService meetingAttendanceQueryService;
 
     // 모임 생성
+    @AuthRequired
     @PostMapping
     public ResponseEntity<MeetingResponse> createMeeting(
+        @CurrentUserId UUID currentUserId,
             @Valid @RequestBody CreateMeetingRequest req
     ) {
         MeetingResult result = meetingCommandService.createMeeting(
-                req.toCommand(req.hostId())
+                req.toCommand(currentUserId)
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -91,13 +95,15 @@ public class MeetingController {
     }
 
     // 모임 가입 신청
+    @AuthRequired
     @PostMapping("/{meetingId}/join")
     public ResponseEntity<MeetingJoinResponse> joinMeeting(
             @PathVariable UUID meetingId,
+            @CurrentUserId UUID currentUserId,
             @Valid @RequestBody JoinMeetingRequest req
     ) {
         MeetingJoinResult result = meetingJoinService.createMeetingJoin(
-                req.toCommand(meetingId, req.recruitUserId())
+                req.toCommand(meetingId, currentUserId)
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -105,17 +111,18 @@ public class MeetingController {
     }
 
     // 가입 신청 목록 조회 - 페이징 처리
+    @AuthRequired
     @GetMapping("/{meetingId}/join")
     public PageResponse<MeetingJoinResponse> getMeetingJoinList(
             @PathVariable UUID meetingId,
-            @RequestParam UUID hostId,
+            @CurrentUserId UUID currentUserId,
             @RequestParam(required = false) MeetingJoinStatus joinStatus,
             PageRequest pageRequest
     ) {
         // 최신 가입 신청이 먼저 보이도록 생성일 내림차순 정렬
         Page<MeetingJoinResult> results = meetingJoinService.getMeetingJoinList(
                 meetingId,
-                hostId,
+                currentUserId,
                 joinStatus,
                 pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"))
         );
@@ -124,16 +131,17 @@ public class MeetingController {
     }
 
     // 모임 가입 승인
+    @AuthRequired
     @PostMapping("/{meetingId}/join/{joinId}/approve")
     public MeetingJoinResponse approveMeetingJoin(
             @PathVariable UUID meetingId,
             @PathVariable UUID joinId,
-            @RequestParam UUID hostId // TODO: 인증 전 임시 모임장 식별
+            @CurrentUserId UUID currentUserId
     ) {
         MeetingJoinResult result = meetingJoinService.approveMeetingJoin(
                 meetingId,
                 joinId,
-                hostId
+                currentUserId
         );
 
         return MeetingJoinResponse.from(result);

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
@@ -13,8 +13,6 @@ import java.util.UUID;
 
 // 모임 생성 요청 DTO
 public record CreateMeetingRequest(
-        @NotNull
-        UUID hostId, // 모임장 ID
 
         String bookId, // 책 ID
 
@@ -51,9 +49,9 @@ public record CreateMeetingRequest(
 ) {
 
     // 요청 DTO → 생성 커맨드 변환
-    public CreateMeetingCommand toCommand(UUID createdBy) {
+    public CreateMeetingCommand toCommand(UUID currentUserId) {
         return new CreateMeetingCommand(
-                hostId,
+            currentUserId,
                 bookId,
                 title,
                 description,
@@ -65,7 +63,7 @@ public record CreateMeetingRequest(
                 ruleMemo,
                 recruitRate,
                 freePaid,
-                createdBy
+                currentUserId // createdBy
         );
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/CreateMeetingRequest.java
@@ -51,7 +51,7 @@ public record CreateMeetingRequest(
     // 요청 DTO → 생성 커맨드 변환
     public CreateMeetingCommand toCommand(UUID currentUserId) {
         return new CreateMeetingCommand(
-            currentUserId,
+                currentUserId,
                 bookId,
                 title,
                 description,

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/JoinMeetingRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/JoinMeetingRequest.java
@@ -7,20 +7,18 @@ import java.util.UUID;
 
 // 모임 가입 신청 요청 DTO
 public record JoinMeetingRequest(
-        @NotNull
-        UUID recruitUserId, // 가입 신청 유저 ID
 
         @Size(max = 500)
         String content // 가입 신청 내용
 ) {
 
     // 요청 DTO → 가입 커맨드 변환
-    public JoinMeetingCommand toCommand(UUID meetingId, UUID createdBy) {
+    public JoinMeetingCommand toCommand(UUID meetingId, UUID currentUserId) {
         return new JoinMeetingCommand(
                 meetingId,
-                recruitUserId,
+                currentUserId, //recruitUserId
                 content,
-                createdBy
+                currentUserId // createdBy
         );
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/JoinMeetingRequest.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/request/JoinMeetingRequest.java
@@ -1,7 +1,6 @@
 package com.pagely.meetingservice.meeting.presentation.dto.request;
 
 import com.pagely.meetingservice.meeting.application.dto.command.JoinMeetingCommand;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.UUID;
 


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 모임 생성/가입/가입 신청 목록 조회/가입 승인 API에 게이트웨이 인증 컨텍스트 적용
- 요청 바디/쿼리 기반 식별자(`hostId`, `recruitUserId`, `hostId query`) 의존을 제거하고 `@CurrentUserId` 기반으로 통일
- 인증 필수 엔드포인트에 `@AuthRequired`를 적용해 미인증 요청이 공통 인증 계층에서 차단되도록 정리

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #49   \


## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1055" height="563" alt="image" src="https://github.com/user-attachments/assets/1ac99771-b27a-49d8-8659-be822fdbe245" />
<img width="1055" height="697" alt="image" src="https://github.com/user-attachments/assets/7d461eeb-6ac3-4878-bb41-603cc3b5ca68" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 미팅 생성, 참여, 목록 조회 및 승인 엔드포인트에 필수 인증 요구사항 추가
* 인증된 사용자 정보를 기반으로 사용자 식별 체계 개선

## 업데이트
* 내부 라이브러리 의존성 버전 업그레이드

<!-- end of auto-generated comment: release notes by coderabbit.ai -->