### PR TITLE
Feat/43 Kafka 이벤트 페이로드 구조 및 인증 컨텍스트 기반 이벤트 발행 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
     runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/pagely/meetingservice/meeting/application/port/EventPublisher.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/port/EventPublisher.java
@@ -1,0 +1,11 @@
+package com.pagely.meetingservice.meeting.application.port;
+
+import com.pagely.meetingservice.meeting.domain.event.BaseEvent;
+
+// 이벤트 발행 책임을 추상화한 포트
+// 애플리케이션 서비스는 Kafka를 직접 알지 않고 이 인터페이스에만 의존한다.
+public interface EventPublisher {
+
+    // 도메인 이벤트를 외부 메시지 브로커로 발행한다.
+    void publish(BaseEvent event);
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
@@ -3,6 +3,9 @@ package com.pagely.meetingservice.meeting.application.service;
 import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateAttendanceStatusCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingAttendanceResult;
+import com.pagely.meetingservice.meeting.application.port.EventPublisher;
+import com.pagely.meetingservice.meeting.domain.event.MeetingAttendanceJoinedEvent;
+import com.pagely.meetingservice.meeting.domain.event.MeetingAttendanceStatusChangedEvent;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingAttendanceErrorCode;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
@@ -31,6 +34,7 @@ public class MeetingAttendanceCommandService {
     private final MeetingScheduleRepository meetingScheduleRepository;
     private final MeetingMemberRepository meetingMemberRepository;
     private final MeetingAttendanceRepository meetingAttendanceRepository;
+    private final EventPublisher eventPublisher;
 
     // 모임 일정 참석 등록
     @Transactional
@@ -77,9 +81,17 @@ public class MeetingAttendanceCommandService {
                 userId
         );
 
-        // 생성된 참석 정보를 저장 후 결과 DTO로 변환
+        // 생성된 참석 정보 저장
         MeetingAttendance saved = meetingAttendanceRepository.save(attendance);
 
+        // 출석 등록 이벤트 메시지 생성
+        // 저장된 출석 ID를 기준으로 ATTENDANCE 도메인 이벤트를 구성한다.
+        MeetingAttendanceJoinedEvent event = MeetingAttendanceJoinedEvent.of(saved);
+
+        // 출석 등록 이벤트를 Kafka로 발행한다.
+        eventPublisher.publish(event);
+
+        // 저장된 출석 결과 DTO 반환
         return MeetingAttendanceResult.from(saved);
     }
 
@@ -152,6 +164,13 @@ public class MeetingAttendanceCommandService {
                 command.note(),
                 command.updatedBy()
         );
+
+        // 출석 상태 변경 이벤트 메시지 생성
+        // 상태 변경 이후 생성해야 변경된 상태, 체크 시각, 비고가 payload에 담긴다.
+        MeetingAttendanceStatusChangedEvent event = MeetingAttendanceStatusChangedEvent.of(attendance);
+
+        // 출석 상태 변경 이벤트를 Kafka로 발행한다.
+        eventPublisher.publish(event);
 
         // 출석 상태 변경 결과에 따라 모임원의 패널티 카운트를 누적한다.
         // - LATE: 지각 수 +1, 경고 수 +1, 지각 3회마다 결석 수 +1

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingCommandService.java
@@ -3,6 +3,10 @@ package com.pagely.meetingservice.meeting.application.service;
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingResult;
 import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberRole;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberStatus;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingCommandService {
 
     private final MeetingRepository meetingRepository;
+    private final MeetingMemberRepository meetingMemberRepository;
 
     // 모임 생성
     @Transactional
@@ -24,9 +29,26 @@ public class MeetingCommandService {
         UUID meetingId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
 
+        // 모임 엔티티 생성
         Meeting meeting = command.toMeeting(meetingId, now);
 
+        // 모임 저장
         Meeting saved = meetingRepository.save(meeting);
+
+        // 모임 생성자는 자동으로 모임장 멤버로 등록한다.
+        MeetingMember hostMember = MeetingMember.create(
+                UUID.randomUUID(),
+                saved.getId(),
+                saved.getHostId(),
+                MeetingMemberRole.HOST,
+                MeetingMemberStatus.ACTIVE,
+                now,
+                saved.getHostId()
+        );
+
+        // 모임장 멤버 저장
+        meetingMemberRepository.save(hostMember);
+
         return MeetingResult.from(saved);
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleCommandService.java
@@ -4,6 +4,9 @@ import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateScheduleStatusCommand;
 import com.pagely.meetingservice.meeting.application.dto.result.MeetingScheduleResult;
+import com.pagely.meetingservice.meeting.application.port.EventPublisher;
+import com.pagely.meetingservice.meeting.domain.event.MeetingScheduleCreatedEvent;
+import com.pagely.meetingservice.meeting.domain.event.MeetingScheduleStatusChangedEvent;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
@@ -31,6 +34,7 @@ public class MeetingScheduleCommandService {
     private final MeetingScheduleRepository meetingScheduleRepository;
     private final MeetingMemberRepository meetingMemberRepository;
     private final MeetingAttendanceRepository meetingAttendanceRepository;
+    private final EventPublisher eventPublisher;
 
     // 모임 일정 생성
     @Transactional
@@ -66,9 +70,17 @@ public class MeetingScheduleCommandService {
                 command.requesterId()
         );
 
-        // 생성된 일정 저장 후 결과 DTO로 변환
+        // 생성된 일정 저장
         MeetingSchedule savedSchedule = meetingScheduleRepository.save(schedule);
 
+        // 일정 생성 이벤트 메시지 생성
+        // 저장된 일정 ID와 최종 상태를 payload에 담기 위해 저장 이후 이벤트를 생성한다.
+        MeetingScheduleCreatedEvent event = MeetingScheduleCreatedEvent.of(savedSchedule);
+
+        // 일정 생성 이벤트를 Kafka로 발행한다.
+        eventPublisher.publish(event);
+
+        // 저장된 일정 결과 DTO 반환
         return MeetingScheduleResult.from(savedSchedule);
     }
 
@@ -108,6 +120,13 @@ public class MeetingScheduleCommandService {
         } else {
             schedule.changeStatus(command.status(), command.updatedBy());
         }
+
+        // 일정 상태 변경 이벤트 메시지 생성
+        // 상태 변경이 끝난 뒤 생성해야 변경된 최종 상태가 payload에 담긴다.
+        MeetingScheduleStatusChangedEvent event = MeetingScheduleStatusChangedEvent.of(schedule);
+
+        // 일정 상태 변경 이벤트를 Kafka로 발행한다.
+        eventPublisher.publish(event);
 
         return MeetingScheduleResult.from(schedule);
     }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/event/BaseEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/event/BaseEvent.java
@@ -1,0 +1,33 @@
+package com.pagely.meetingservice.meeting.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public abstract class BaseEvent {
+
+    private final String eventId;
+    private final String eventType;
+    private final String domainType;
+    private final String domainId;
+    private final Instant occurredAt;
+    private final Object payload;
+
+    protected BaseEvent(String domainType, UUID domainId, Object payload) {
+        this(domainType, domainId == null ? null : domainId.toString(), payload);
+    }
+
+    protected BaseEvent(String domainType, Object payload) {
+        this(domainType, (String) null, payload);
+    }
+
+    protected BaseEvent(String domainType, String domainId, Object payload) {
+        this.eventId = UUID.randomUUID().toString();
+        this.eventType = this.getClass().getSimpleName();
+        this.domainType = domainType;
+        this.domainId = domainId;
+        this.occurredAt = Instant.now();
+        this.payload = payload;
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingAttendanceJoinedEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingAttendanceJoinedEvent.java
@@ -1,0 +1,38 @@
+package com.pagely.meetingservice.meeting.domain.event;
+
+import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class MeetingAttendanceJoinedEvent extends BaseEvent {
+
+    private static final String DOMAIN_TYPE = "ATTENDANCE";
+
+    private MeetingAttendanceJoinedEvent(UUID attendanceId, Object payload) {
+        super(DOMAIN_TYPE, attendanceId, payload);
+    }
+
+    public static MeetingAttendanceJoinedEvent of(MeetingAttendance attendance) {
+        return new MeetingAttendanceJoinedEvent(
+                attendance.getId(),
+                new Payload(
+                        attendance.getId(),
+                        attendance.getMeetingId(),
+                        attendance.getScheduleId(),
+                        attendance.getUserId(),
+                        attendance.getStatus()
+                )
+        );
+    }
+
+    public record Payload(
+            UUID attendanceId,
+            UUID meetingId,
+            UUID scheduleId,
+            UUID userId,
+            AttendanceStatus status
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingAttendanceStatusChangedEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingAttendanceStatusChangedEvent.java
@@ -1,0 +1,43 @@
+package com.pagely.meetingservice.meeting.domain.event;
+
+import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class MeetingAttendanceStatusChangedEvent extends BaseEvent {
+
+    private static final String DOMAIN_TYPE = "ATTENDANCE";
+
+    private MeetingAttendanceStatusChangedEvent(UUID attendanceId, Object payload) {
+        super(DOMAIN_TYPE, attendanceId, payload);
+    }
+
+    public static MeetingAttendanceStatusChangedEvent of(MeetingAttendance attendance) {
+        return new MeetingAttendanceStatusChangedEvent(
+                attendance.getId(),
+                new Payload(
+                        attendance.getId(),
+                        attendance.getMeetingId(),
+                        attendance.getScheduleId(),
+                        attendance.getUserId(),
+                        attendance.getStatus(),
+                        attendance.getCheckedAt(),
+                        attendance.getNote()
+                )
+        );
+    }
+
+    public record Payload(
+            UUID attendanceId,
+            UUID meetingId,
+            UUID scheduleId,
+            UUID userId,
+            AttendanceStatus status,
+            LocalDateTime checkedAt,
+            String note
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingCreatedEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingCreatedEvent.java
@@ -1,0 +1,59 @@
+package com.pagely.meetingservice.meeting.domain.event;
+
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.model.MeetingStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingType;
+import com.pagely.meetingservice.meeting.domain.model.ReadingLevel;
+import com.pagely.meetingservice.meeting.domain.model.RecruitRate;
+import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class MeetingCreatedEvent extends BaseEvent {
+
+    private static final String DOMAIN_TYPE = "MEETING";
+
+    private MeetingCreatedEvent(UUID meetingId, Object payload) {
+        super(DOMAIN_TYPE, meetingId, payload);
+    }
+
+    public static MeetingCreatedEvent of(Meeting meeting) {
+        return new MeetingCreatedEvent(
+                meeting.getId(),
+                new Payload(
+                        meeting.getId(),
+                        meeting.getHostId(),
+                        meeting.getBookId(),
+                        meeting.getTitle(),
+                        meeting.getMeetingType(),
+                        meeting.getMeetingStatus(),
+                        meeting.getRecruitStatus(),
+                        meeting.getRecruitStartAt(),
+                        meeting.getRecruitEndAt(),
+                        meeting.getRecruitMax(),
+                        meeting.getReadingLevel(),
+                        meeting.getRecruitRate(),
+                        meeting.isFreePaid()
+                )
+        );
+    }
+
+    public record Payload(
+            UUID meetingId,
+            UUID hostId,
+            String bookId,
+            String title,
+            MeetingType meetingType,
+            MeetingStatus meetingStatus,
+            RecruitStatus recruitStatus,
+            LocalDateTime recruitStartAt,
+            LocalDateTime recruitEndAt,
+            int recruitMax,
+            ReadingLevel readingLevel,
+            RecruitRate recruitRate,
+            boolean freePaid
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingScheduleCreatedEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingScheduleCreatedEvent.java
@@ -1,0 +1,43 @@
+package com.pagely.meetingservice.meeting.domain.event;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class MeetingScheduleCreatedEvent extends BaseEvent {
+
+    private static final String DOMAIN_TYPE = "SCHEDULE";
+
+    private MeetingScheduleCreatedEvent(UUID scheduleId, Object payload) {
+        super(DOMAIN_TYPE, scheduleId, payload);
+    }
+
+    public static MeetingScheduleCreatedEvent of(MeetingSchedule schedule) {
+        return new MeetingScheduleCreatedEvent(
+                schedule.getId(),
+                new Payload(
+                        schedule.getId(),
+                        schedule.getMeetingId(),
+                        schedule.getScheduleNumber(),
+                        schedule.getBookId(),
+                        schedule.getStatus(),
+                        schedule.getStartAt(),
+                        schedule.getDiscussionNote()
+                )
+        );
+    }
+
+    public record Payload(
+            UUID scheduleId,
+            UUID meetingId,
+            int scheduleNumber,
+            String bookId,
+            MeetingScheduleStatus status,
+            LocalDateTime startAt,
+            String discussionNote
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingScheduleStatusChangedEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingScheduleStatusChangedEvent.java
@@ -1,0 +1,34 @@
+package com.pagely.meetingservice.meeting.domain.event;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class MeetingScheduleStatusChangedEvent extends BaseEvent {
+
+    private static final String DOMAIN_TYPE = "SCHEDULE";
+
+    private MeetingScheduleStatusChangedEvent(UUID scheduleId, Object payload) {
+        super(DOMAIN_TYPE, scheduleId, payload);
+    }
+
+    public static MeetingScheduleStatusChangedEvent of(MeetingSchedule schedule) {
+        return new MeetingScheduleStatusChangedEvent(
+                schedule.getId(),
+                new Payload(
+                        schedule.getId(),
+                        schedule.getMeetingId(),
+                        schedule.getStatus()
+                )
+        );
+    }
+
+    public record Payload(
+            UUID scheduleId,
+            UUID meetingId,
+            MeetingScheduleStatus status
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/KafkaEventPublisher.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/KafkaEventPublisher.java
@@ -1,0 +1,27 @@
+package com.pagely.meetingservice.meeting.infrastructure.messaging;
+
+import com.pagely.meetingservice.meeting.application.port.EventPublisher;
+import com.pagely.meetingservice.meeting.domain.event.BaseEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+// Kafka를 이용해 이벤트를 발행하는 구현체
+@Component
+@RequiredArgsConstructor
+public class KafkaEventPublisher implements EventPublisher {
+
+    private static final String MEETING_EVENT_TOPIC = "meeting-event";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void publish(BaseEvent event) {
+        // domainId를 메시지 키로 사용하여 같은 도메인 이벤트가 같은 파티션으로 갈 수 있도록 한다.
+        kafkaTemplate.send(
+                MEETING_EVENT_TOPIC,
+                event.getDomainId(),
+                event
+        );
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -77,13 +77,9 @@ public class MeetingController {
                 .body(MeetingResponse.from(result));
     }
 
-    // 모임 전체 조회 - 페이징 처리
-    @AuthRequired
+    // 모임 전체 조회
     @GetMapping
-    public PageResponse<MeetingSummaryResponse> getMeetings(
-            @CurrentUserId UUID currentUserId,
-            PageRequest pageRequest
-    ) {
+    public PageResponse<MeetingSummaryResponse> getMeetings(PageRequest pageRequest) {
         Page<MeetingSummaryResult> results = meetingQueryService.getMeetings(
                 pageRequest.toPageable()
         );
@@ -92,12 +88,8 @@ public class MeetingController {
     }
 
     // 모임 상세 조회
-    @AuthRequired
     @GetMapping("/{meetingId}")
-    public MeetingResponse getMeeting(
-            @PathVariable UUID meetingId,
-            @CurrentUserId UUID currentUserId
-    ) {
+    public MeetingResponse getMeeting(@PathVariable UUID meetingId) {
         MeetingResult result = meetingQueryService.getMeeting(meetingId);
         return MeetingResponse.from(result);
     }
@@ -118,7 +110,7 @@ public class MeetingController {
                 .body(MeetingJoinResponse.from(result));
     }
 
-    // 가입 신청 목록 조회 - 페이징 처리
+    // 가입 신청 목록 조회
     @AuthRequired
     @GetMapping("/{meetingId}/join")
     public PageResponse<MeetingJoinResponse> getMeetingJoinList(
@@ -127,7 +119,6 @@ public class MeetingController {
             @RequestParam(required = false) MeetingJoinStatus joinStatus,
             PageRequest pageRequest
     ) {
-        // 최신 가입 신청이 먼저 보이도록 생성일 내림차순 정렬
         Page<MeetingJoinResult> results = meetingJoinService.getMeetingJoinList(
                 meetingId,
                 currentUserId,
@@ -177,7 +168,7 @@ public class MeetingController {
                 .body(MeetingScheduleResponse.from(result));
     }
 
-    // 모임 일정 목록 조회 - 페이징 처리
+    // 모임 일정 목록 조회
     @AuthRequired
     @GetMapping("/{meetingId}/schedules")
     public PageResponse<MeetingScheduleResponse> getMeetingSchedules(
@@ -243,7 +234,7 @@ public class MeetingController {
         return ResponseEntity.ok(MeetingScheduleResponse.from(result));
     }
 
-    // 특정 일정 출석부 조회 - 페이징 처리
+    // 특정 일정 출석부 조회
     @AuthRequired
     @GetMapping("/{meetingId}/schedules/{scheduleId}/attendances")
     public MeetingAttendancePageResponse getScheduleAttendances(
@@ -268,7 +259,7 @@ public class MeetingController {
         return MeetingAttendancePageResponse.from(results, statistics);
     }
 
-    // 내 출석부 조회 - 페이징 처리
+    // 내 출석부 조회
     @AuthRequired
     @GetMapping("/{meetingId}/attendances/me")
     public MeetingAttendancePageResponse getMyAttendances(

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -78,8 +78,12 @@ public class MeetingController {
     }
 
     // 모임 전체 조회 - 페이징 처리
+    @AuthRequired
     @GetMapping
-    public PageResponse<MeetingSummaryResponse> getMeetings(PageRequest pageRequest) {
+    public PageResponse<MeetingSummaryResponse> getMeetings(
+            @CurrentUserId UUID currentUserId,
+            PageRequest pageRequest
+    ) {
         Page<MeetingSummaryResult> results = meetingQueryService.getMeetings(
                 pageRequest.toPageable()
         );
@@ -88,8 +92,12 @@ public class MeetingController {
     }
 
     // 모임 상세 조회
+    @AuthRequired
     @GetMapping("/{meetingId}")
-    public MeetingResponse getMeeting(@PathVariable UUID meetingId) {
+    public MeetingResponse getMeeting(
+            @PathVariable UUID meetingId,
+            @CurrentUserId UUID currentUserId
+    ) {
         MeetingResult result = meetingQueryService.getMeeting(meetingId);
         return MeetingResponse.from(result);
     }
@@ -148,9 +156,11 @@ public class MeetingController {
     }
 
     // 모임 일정 생성
+    @AuthRequired
     @PostMapping("/{meetingId}/schedules")
     public ResponseEntity<MeetingScheduleResponse> createMeetingSchedule(
             @PathVariable UUID meetingId,
+            @CurrentUserId UUID currentUserId,
             @Valid @RequestBody CreateMeetingScheduleRequest req
     ) {
         CreateMeetingScheduleCommand command = new CreateMeetingScheduleCommand(
@@ -158,8 +168,7 @@ public class MeetingController {
                 req.bookId(),
                 req.startAt(),
                 req.discussionNote(),
-                // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경
-                UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+                currentUserId
         );
 
         MeetingScheduleResult result = meetingScheduleCommandService.createSchedule(command);
@@ -169,12 +178,13 @@ public class MeetingController {
     }
 
     // 모임 일정 목록 조회 - 페이징 처리
+    @AuthRequired
     @GetMapping("/{meetingId}/schedules")
     public PageResponse<MeetingScheduleResponse> getMeetingSchedules(
             @PathVariable UUID meetingId,
+            @CurrentUserId UUID currentUserId,
             PageRequest pageRequest
     ) {
-        // 회차 번호 오름차순 기준으로 페이징 조회
         Page<MeetingScheduleResult> results = meetingScheduleQueryService.getSchedules(
                 meetingId,
                 pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "scheduleNumber"))
@@ -184,28 +194,29 @@ public class MeetingController {
     }
 
     // 모임 일정 상세 조회
+    @AuthRequired
     @GetMapping("/{meetingId}/schedules/{scheduleId}")
     public MeetingScheduleResponse getMeetingSchedule(
             @PathVariable UUID meetingId,
-            @PathVariable UUID scheduleId
+            @PathVariable UUID scheduleId,
+            @CurrentUserId UUID currentUserId
     ) {
         MeetingScheduleResult result = meetingScheduleQueryService.getSchedule(meetingId, scheduleId);
         return MeetingScheduleResponse.from(result);
     }
 
     // 모임 일정 참석 등록
+    @AuthRequired
     @PostMapping("/{meetingId}/schedules/{scheduleId}/join")
     public ResponseEntity<MeetingAttendanceResponse> joinMeetingSchedule(
             @PathVariable UUID meetingId,
-            @PathVariable UUID scheduleId
+            @PathVariable UUID scheduleId,
+            @CurrentUserId UUID currentUserId
     ) {
-        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경
-        UUID userId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
-
         MeetingAttendanceResult result = meetingAttendanceCommandService.joinSchedule(
                 meetingId,
                 scheduleId,
-                userId
+                currentUserId
         );
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -213,19 +224,18 @@ public class MeetingController {
     }
 
     // 모임 일정 상태 변경
+    @AuthRequired
     @PatchMapping("/{meetingId}/schedules/{scheduleId}/status")
     public ResponseEntity<MeetingScheduleResponse> changeMeetingScheduleStatus(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
+            @CurrentUserId UUID currentUserId,
             @Valid @RequestBody UpdateScheduleStatusRequest req
     ) {
-        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경
-        UUID updatedBy = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-
         UpdateScheduleStatusCommand command = req.toCommand(
                 meetingId,
                 scheduleId,
-                updatedBy
+                currentUserId
         );
 
         MeetingScheduleResult result = meetingScheduleCommandService.changeScheduleStatus(command);
@@ -234,72 +244,65 @@ public class MeetingController {
     }
 
     // 특정 일정 출석부 조회 - 페이징 처리
+    @AuthRequired
     @GetMapping("/{meetingId}/schedules/{scheduleId}/attendances")
     public MeetingAttendancePageResponse getScheduleAttendances(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
+            @CurrentUserId UUID currentUserId,
             PageRequest pageRequest
     ) {
-        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID: 모임장)
-        UUID userId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-
-        // 출석 목록은 페이징 처리
         Page<MeetingAttendanceResult> results = meetingAttendanceQueryService.getScheduleAttendances(
                 meetingId,
                 scheduleId,
-                userId,
+                currentUserId,
                 pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "createdAt"))
         );
 
-        // 출석 통계는 전체 출석 기록 기준으로 계산
         AttendanceStatisticsResult statistics = meetingAttendanceQueryService.getScheduleAttendanceStatistics(
                 meetingId,
                 scheduleId,
-                userId
+                currentUserId
         );
 
         return MeetingAttendancePageResponse.from(results, statistics);
     }
 
     // 내 출석부 조회 - 페이징 처리
+    @AuthRequired
     @GetMapping("/{meetingId}/attendances/me")
     public MeetingAttendancePageResponse getMyAttendances(
             @PathVariable UUID meetingId,
+            @CurrentUserId UUID currentUserId,
             PageRequest pageRequest
     ) {
-        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경 (테스트 ID: 모임원)
-        UUID userId = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
-
-        // 내 출석 이력은 페이징 처리
         Page<MeetingAttendanceResult> results = meetingAttendanceQueryService.getMyAttendances(
                 meetingId,
-                userId,
+                currentUserId,
                 pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "createdAt"))
         );
 
-        // 내 출석 통계는 전체 출석 이력 기준으로 계산
         AttendanceStatisticsResult statistics = meetingAttendanceQueryService.getMyAttendanceStatistics(
                 meetingId,
-                userId
+                currentUserId
         );
 
         return MeetingAttendancePageResponse.from(results, statistics);
     }
 
     // 출석 상태 변경
+    @AuthRequired
     @PatchMapping("/{meetingId}/schedules/{scheduleId}/attendances")
     public ResponseEntity<MeetingAttendanceResponse> changeAttendanceStatus(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
+            @CurrentUserId UUID currentUserId,
             @Valid @RequestBody UpdateAttendanceStatusRequest req
     ) {
-        // TODO: 인증 컨텍스트 연결 후 현재 로그인 사용자 ID로 변경
-        UUID updatedBy = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-
         UpdateAttendanceStatusCommand command = req.toCommand(
                 meetingId,
                 scheduleId,
-                updatedBy
+                currentUserId
         );
 
         MeetingAttendanceResult result = meetingAttendanceCommandService.changeAttendanceStatus(command);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,14 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+  kafka:
+    bootstrap-servers: ${KAFKA_EXTERNAL_HOST}:${KAFKA_EXTERNAL_PORT}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 모임 서비스 이벤트 페이로드 구조(BaseEvent + Payload) 설계 및 적용
- 일정/출석부 도메인에 Kafka 이벤트 발행 로직 추가
- Gateway 인증 컨텍스트 기반 사용자 정보(@CurrentUserId) 적용
- Kafka 설정(application.yml) 추가 및 환경 구성

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #43 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #43  

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

- 이벤트 메시지 구조 표준화 (BaseEvent + Payload)
- 일정 생성 / 상태 변경 / 출석 관련 이벤트 발행 적용
- 하드코딩된 userId 제거 및 인증 컨텍스트 기반 처리로 변경
- Kafka producer 설정 추가 (bootstrap-server, serializer 등)
- 이벤트 발행을 위한 공통 모듈 구조 정리

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="1279" height="706" alt="스크린샷 2026-04-30 오전 3 02 06" src="https://github.com/user-attachments/assets/c8249ca1-f082-4eae-b78d-cb8a7a29dd58" />
<img width="1285" height="602" alt="스크린샷 2026-04-30 오전 3 02 14" src="https://github.com/user-attachments/assets/aea2a102-5463-477b-94cf-588a6580e128" />
<img width="1286" height="695" alt="스크린샷 2026-04-30 오전 3 03 26" src="https://github.com/user-attachments/assets/cd850a63-57c5-44bc-b61a-11d9a98534f6" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 회의·일정·참석 관련 변경 사항에 대해 도메인 이벤트를 발행하도록 추가
  * 회의 생성 시 호스트가 자동으로 회의 멤버로 등록되도록 처리

* **Bug Fixes / Improvements**
  * 여러 엔드포인트에 인증 적용 및 실제 사용자 컨텍스트로 동작하도록 전환

* **Chores**
  * Kafka 메시징 라이브러리 및 프로듀서 설정 추가 (메시지 직렬화 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->