### PR TITLE
Feat/55 가입한 모임 id 목록 반환 API

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingInternalQueryService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingInternalQueryService.java
@@ -1,0 +1,34 @@
+package com.pagely.meetingservice.meeting.application.service;
+
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberStatus;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MeetingInternalQueryService {
+
+    // 조회를 허용할 멤버 상태
+    private static final List<MeetingMemberStatus> READABLE_STATUSES = List.of(
+            MeetingMemberStatus.ACTIVE,
+            MeetingMemberStatus.LEFT,
+            MeetingMemberStatus.REMOVED,
+            MeetingMemberStatus.EXPELLED
+    );
+
+    private final MeetingMemberRepository meetingMemberRepository;
+
+
+    // 특정 유저가 조회할 수 있는 모임의 id 목록 반환
+    public List<UUID> getReadableMeetingIds(UUID userId) {
+        return meetingMemberRepository.findMeetingIdsByUserIdAndStatuses(
+                userId,
+                READABLE_STATUSES);
+    }
+
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/repository/MeetingMemberRepository.java
@@ -33,4 +33,11 @@ public interface MeetingMemberRepository {
 
     // 특정 유저가 해당 모임 멤버인지 확인
     boolean existsByMeetingIdAndUserId(UUID meetingId, UUID userId);
+
+    // 특정 유저가 속한 모임의 id 목록 조회
+    List<UUID> findMeetingIdsByUserIdAndStatuses(
+            UUID userId,
+            List<MeetingMemberStatus> statuses
+    );
+
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingMemberRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaMeetingMemberRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 // 모임 멤버 JPA Repository
 public interface JpaMeetingMemberRepository extends JpaRepository<MeetingMember, UUID> {
@@ -42,5 +44,12 @@ public interface JpaMeetingMemberRepository extends JpaRepository<MeetingMember,
             UUID meetingId,
             UUID userId,
             MeetingMemberStatus status
+    );
+
+    // 유저가 속한 모임의 id 목록 조회
+    @Query("select distinct m.meetingId from MeetingMember m where m.userId = :userId and m.status in :statuses and m.deletedAt is null")
+    List<UUID> findDistinctMeetingIdsByUserIdAndStatusesAndDeletedAtIsNull(
+            @Param("userId") UUID userId,
+            @Param("statuses") List<MeetingMemberStatus> statuses
     );
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingMemberRepositoryAdapter.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/MeetingMemberRepositoryAdapter.java
@@ -86,4 +86,13 @@ public class MeetingMemberRepositoryAdapter implements MeetingMemberRepository {
                 MeetingMemberStatus.ACTIVE
         );
     }
+
+    // 특정 유저가 속한 모임의 id 목록 조회
+    @Override
+    public List<UUID> findMeetingIdsByUserIdAndStatuses(UUID userId, List<MeetingMemberStatus> statuses) {
+        return jpaMeetingMemberRepository.findDistinctMeetingIdsByUserIdAndStatusesAndDeletedAtIsNull(
+                userId,
+                statuses
+        );
+    }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingInternalController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingInternalController.java
@@ -1,0 +1,30 @@
+package com.pagely.meetingservice.meeting.presentation.controller;
+
+import com.pagely.meetingservice.meeting.application.service.MeetingInternalQueryService;
+import com.pagely.meetingservice.meeting.presentation.dto.response.InternalReadableMeetingIdsResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/meetings")
+@RequiredArgsConstructor
+public class MeetingInternalController {
+
+    private final MeetingInternalQueryService meetingInternalQueryService;
+
+    // 권한 기준 모임 ID 목록 조회
+    @GetMapping("/access/readable")
+    public ResponseEntity<InternalReadableMeetingIdsResponse> getReadableMeetingIds(@RequestParam UUID userId) {
+        return ResponseEntity.ok(
+                InternalReadableMeetingIdsResponse.of(
+                        meetingInternalQueryService.getReadableMeetingIds(userId)
+                )
+        );
+    }
+}
+

--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/InternalReadableMeetingIdsResponse.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/dto/response/InternalReadableMeetingIdsResponse.java
@@ -1,0 +1,15 @@
+package com.pagely.meetingservice.meeting.presentation.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InternalReadableMeetingIdsResponse(
+        List<UUID> meetingIds
+) {
+    // 서비스 결과 리스트 -> DTO 변환
+    public static InternalReadableMeetingIdsResponse of(List<UUID> meetingIds) {
+        return new InternalReadableMeetingIdsResponse(
+                meetingIds == null ? List.of() : meetingIds
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- `GET /internal/meetings/access/readable?userId={uuid}`를 추가해, 유저 기준 조회 가능한 모임 ID 목록을 반환
- 조회 권한 기준 상태를 `ACTIVE`, `LEFT`, `REMOVED`, `EXPELLED`로 정의해 강퇴/탈퇴 사용자도 조회가 가능하도록 적용

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #55   \

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1047" height="521" alt="image" src="https://github.com/user-attachments/assets/fc680ec8-a10e-493a-a521-3caa6acf1330" />
가입한 모임이 없는 경우
<br>
<br>

<img width="801" height="571" alt="image" src="https://github.com/user-attachments/assets/82bc448c-0f3a-446d-9110-cc8172753ea7" />
가입한 모임이 있는 경우
<br>
<br>

<img width="793" height="616" alt="image" src="https://github.com/user-attachments/assets/afa7f2bd-e600-4d5c-98a8-0d1dd6236046" />
사용자 UUID 형식 오류
<br>
<br>

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 특정 사용자가 열람 가능한 모든 회의의 목록을 조회할 수 있는 새로운 내부 API 엔드포인트가 추가되었습니다. 요청 매개변수로 사용자 ID를 전달하여 접근 권한이 있는 회의 식별자를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->