### PR TITLE
Feat/59 출석 패널티 로직 이벤트 기반 분리 및 Consumer 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation "com.pagely:common:2.0.0"
+    implementation "com.pagely:common:2.0.1"
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
@@ -112,7 +112,6 @@ public class MeetingAttendanceCommandService {
         }
 
         // 출석 상태 변경은 진행 중인 일정에서만 가능
-        // 예정/완료/취소된 일정의 출석 상태 변경 방지
         if (!schedule.isOngoing()) {
             throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ONGOING_SCHEDULE_CAN_CHANGE_ATTENDANCE);
         }
@@ -152,35 +151,28 @@ public class MeetingAttendanceCommandService {
         AttendanceStatus finalStatus = command.status();
 
         // 출석 요청이 들어와도 일정 시작 후 10분이 지난 경우 자동으로 지각 처리
-        // 출석 시간 정책을 애플리케이션 서비스에서 일관되게 적용
         if (command.status() == AttendanceStatus.ATTENDED
                 && LocalDateTime.now().isAfter(schedule.getStartAt().plusMinutes(10))) {
             finalStatus = AttendanceStatus.LATE;
         }
 
-        // 최종 출석 상태, 비고, 수정자를 반영
+        // 출석 상태만 변경한다.
+        // 경고/지각/결석 누적은 이 메서드에서 직접 처리하지 않고,
+        // 출석 상태 변경 이벤트를 수신한 Consumer가 담당한다.
         attendance.changeStatus(
                 finalStatus,
                 command.note(),
                 command.updatedBy()
         );
 
-        // 출석 상태 변경 이벤트 메시지 생성
-        // 상태 변경 이후 생성해야 변경된 상태, 체크 시각, 비고가 payload에 담긴다.
-        MeetingAttendanceStatusChangedEvent event = MeetingAttendanceStatusChangedEvent.of(attendance);
+        // 출석 상태 변경 이벤트 생성
+        MeetingAttendanceStatusChangedEvent event = MeetingAttendanceStatusChangedEvent.of(
+                attendance,
+                command.updatedBy()
+        );
 
-        // 출석 상태 변경 이벤트를 Kafka로 발행한다.
+        // 출석 상태 변경 이벤트 발행
         eventPublisher.publish(event);
-
-        // 출석 상태 변경 결과에 따라 모임원의 패널티 카운트를 누적한다.
-        // - LATE: 지각 수 +1, 경고 수 +1, 지각 3회마다 결석 수 +1
-        // - ABSENT: 결석 수 +1
-        // - ATTENDED, EXCUSED: 패널티 없음
-        //
-        // 주의:
-        // 출석 상태는 PENDING에서 한 번만 변경 가능하므로,
-        // 동일 출석 건에 대한 패널티 중복 누적도 함께 방지된다.
-        targetMember.applyAttendancePenalty(finalStatus, command.updatedBy());
 
         return MeetingAttendanceResult.from(attendance);
     }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingAttendanceStatusChangedEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/event/MeetingAttendanceStatusChangedEvent.java
@@ -15,7 +15,10 @@ public class MeetingAttendanceStatusChangedEvent extends BaseEvent {
         super(DOMAIN_TYPE, attendanceId, payload);
     }
 
-    public static MeetingAttendanceStatusChangedEvent of(MeetingAttendance attendance) {
+    public static MeetingAttendanceStatusChangedEvent of(
+            MeetingAttendance attendance,
+            UUID changedBy
+    ) {
         return new MeetingAttendanceStatusChangedEvent(
                 attendance.getId(),
                 new Payload(
@@ -25,7 +28,8 @@ public class MeetingAttendanceStatusChangedEvent extends BaseEvent {
                         attendance.getUserId(),
                         attendance.getStatus(),
                         attendance.getCheckedAt(),
-                        attendance.getNote()
+                        attendance.getNote(),
+                        changedBy
                 )
         );
     }
@@ -37,7 +41,8 @@ public class MeetingAttendanceStatusChangedEvent extends BaseEvent {
             UUID userId,
             AttendanceStatus status,
             LocalDateTime checkedAt,
-            String note
+            String note,
+            UUID changedBy
     ) {
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/exception/MeetingMemberErrorCode.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/exception/MeetingMemberErrorCode.java
@@ -18,6 +18,7 @@ public enum MeetingMemberErrorCode implements ErrorCode {
     INACTIVE_MEMBER(HttpStatus.BAD_REQUEST, "INACTIVE_MEMBER", "활성 상태의 모임원만 수행할 수 있습니다."), // 비활성 모임원
     REMOVED_OR_EXPELLED_MEMBER(HttpStatus.BAD_REQUEST, "REMOVED_OR_EXPELLED_MEMBER",
             "강퇴 또는 제거된 사용자는 가입 신청할 수 없습니다."), // 제거/강퇴 유저 제한
+    INVALID_ATTENDANCE_STATUS(HttpStatus.BAD_REQUEST, "INVALID_ATTENDANCE_STATUS", "유효하지 않은 출석 상태입니다."),
 
     /*
      * =========================================================

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/MeetingMember.java
@@ -1,5 +1,8 @@
 package com.pagely.meetingservice.meeting.domain.model;
 
+import com.pagely.common.entity.BaseEntity;
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,8 +13,6 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-
-import com.pagely.common.entity.BaseEntity;
 
 // 모임원 엔티티
 @Entity
@@ -91,10 +92,10 @@ public class MeetingMember extends BaseEntity {
 
     // 출석 상태에 따른 패널티 반영
     public void applyAttendancePenalty(AttendanceStatus attendanceStatus, UUID updatedBy) {
-        // null 상태가 들어오면 패널티 기준을 판단할 수 없으므로 즉시 종료
-        // 필요하면 BusinessException으로 바꿔도 됨
+
+        // 출석 상태가 null이면 잘못된 이벤트이므로 즉시 예외 발생
         if (attendanceStatus == null) {
-            return;
+            throw new BusinessException(MeetingMemberErrorCode.INVALID_ATTENDANCE_STATUS);
         }
 
         // 정상 출석과 사유 인정 결석은 패널티 대상이 아님
@@ -104,27 +105,30 @@ public class MeetingMember extends BaseEntity {
         }
 
         // 지각 처리
+        // 정책:
+        // - 지각 1회마다 lateCount만 증가
+        // - 지각 3회 누적 시 경고 1회 증가
         if (attendanceStatus == AttendanceStatus.LATE) {
             this.lateCount++;
 
-            // 현재 임시 정책:
-            // 지각 1회는 경고 1회로 누적한다.
-            this.warningCount++;
-
-            // 지각 3회마다 결석 1회로 환산한다.
-            // lateCount = 3  -> absentCount +1
-            // lateCount = 6  -> absentCount +1
-            // lateCount = 9  -> absentCount +1
-            // 실제 LATE 상태를 ABSENT로 바꾸지는 않고,
-            // 모임원 패널티 카운트에만 환산 결석을 누적한다.
+            // 지각 횟수가 3의 배수가 될 때마다 경고 1회 누적
             if (this.lateCount % 3 == 0) {
-                this.absentCount++;
+                this.warningCount++;
             }
         }
 
         // 결석 처리
+        // 정책:
+        // - 결석 1회 누적
+        // - 결석 1회마다 경고 1회 증가
         if (attendanceStatus == AttendanceStatus.ABSENT) {
             this.absentCount++;
+            this.warningCount++;
+        }
+
+        // 경고 3회 이상이면 모임 강퇴 처리
+        if (this.warningCount >= 3) {
+            this.status = MeetingMemberStatus.EXPELLED;
         }
 
         this.updatedBy = updatedBy;

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/model/ProcessedEvent.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/model/ProcessedEvent.java
@@ -1,0 +1,70 @@
+package com.pagely.meetingservice.meeting.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// Kafka Consumer 이벤트 중복 처리 방지용 엔티티
+@Entity
+@Table(name = "p_processed_event")
+public class ProcessedEvent {
+
+    @Id
+    private UUID id;
+
+    // 이벤트를 처리한 Consumer 이름
+    @Column(name = "consumer_name", nullable = false, length = 100)
+    private String consumerName;
+
+    // BaseEvent의 eventId
+    @Column(name = "event_id", nullable = false, length = 100)
+    private String eventId;
+
+    // 이벤트 처리 완료 시각
+    @Column(name = "processed_at", nullable = false)
+    private LocalDateTime processedAt;
+
+    protected ProcessedEvent() {
+    }
+
+    private ProcessedEvent(
+            UUID id,
+            String consumerName,
+            String eventId,
+            LocalDateTime processedAt
+    ) {
+        this.id = id;
+        this.consumerName = consumerName;
+        this.eventId = eventId;
+        this.processedAt = processedAt;
+    }
+
+    // 처리 완료 이벤트 생성
+    public static ProcessedEvent of(String consumerName, String eventId) {
+        return new ProcessedEvent(
+                UUID.randomUUID(),
+                consumerName,
+                eventId,
+                LocalDateTime.now()
+        );
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getConsumerName() {
+        return consumerName;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public LocalDateTime getProcessedAt() {
+        return processedAt;
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
@@ -45,16 +45,19 @@ public class MeetingAttendanceEventConsumer {
             JsonNode root = objectMapper.readTree(message);
 
             // 멱등성 기준은 BaseEvent의 eventId를 사용한다.
-            eventId = root.get("eventId").asText();
+            eventId = requiredText(root, "eventId");
 
             // BaseEvent 내부 payload 필드 추출
             JsonNode payload = root.get("payload");
+            if (payload == null || payload.isNull()) {
+                throw new IllegalArgumentException("Missing required field: payload");
+            }
 
-            attendanceId = UUID.fromString(payload.get("attendanceId").asText());
-            UUID meetingId = UUID.fromString(payload.get("meetingId").asText());
-            UUID userId = UUID.fromString(payload.get("userId").asText());
-            UUID changedBy = UUID.fromString(payload.get("changedBy").asText());
-            AttendanceStatus status = AttendanceStatus.valueOf(payload.get("status").asText());
+            attendanceId = UUID.fromString(requiredText(payload, "attendanceId"));
+            UUID meetingId = UUID.fromString(requiredText(payload, "meetingId"));
+            UUID userId = UUID.fromString(requiredText(payload, "userId"));
+            UUID changedBy = UUID.fromString(requiredText(payload, "changedBy"));
+            AttendanceStatus status = AttendanceStatus.valueOf(requiredText(payload, "status"));
 
             log.info(
                     "출석 상태 변경 이벤트 수신: eventId={}, attendanceId={}, meetingId={}, userId={}, status={}",
@@ -124,7 +127,7 @@ public class MeetingAttendanceEventConsumer {
             );
 
         } catch (BusinessException | IllegalArgumentException e) {
-            // payload 오류, UUID 오류, enum 오류, 모임원 없음 등은 재시도해도 성공하지 않는 비재시도성 오류
+            // payload 필드 누락/공백, UUID 오류, enum 오류, 모임원 없음 등은 재시도해도 성공하지 않는 비재시도성 오류
             // 원본 message에는 note 등 사용자 입력값이 포함될 수 있으므로 로그에 남기지 않는다.
             log.warn(
                     "출석 이벤트 비재시도성 실패: eventId={}, attendanceId={}, reason={}",
@@ -169,5 +172,23 @@ public class MeetingAttendanceEventConsumer {
             // 같은 이벤트가 이미 처리 중이거나 처리 완료된 것으로 보고 skip한다.
             return false;
         }
+    }
+
+    // 필수 문자열 필드 추출
+    // 필드가 없거나 null 또는 공백이면 비재시도성 예외로 분류되도록 IllegalArgumentException을 발생시킨다.
+    private String requiredText(JsonNode node, String fieldName) {
+        JsonNode value = node.get(fieldName);
+
+        if (value == null || value.isNull()) {
+            throw new IllegalArgumentException("Missing required field: " + fieldName);
+        }
+
+        String text = value.asText();
+
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("Blank required field: " + fieldName);
+        }
+
+        return text;
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
@@ -6,10 +6,13 @@ import com.pagely.common.exception.BusinessException;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
 import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.model.ProcessedEvent;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
+import com.pagely.meetingservice.meeting.infrastructure.persistence.JpaProcessedEventRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +23,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MeetingAttendanceEventConsumer {
 
+    private static final String CONSUMER_NAME = "meeting-attendance-event-consumer";
+
     private final MeetingMemberRepository meetingMemberRepository;
+    private final JpaProcessedEventRepository processedEventRepository;
     private final ObjectMapper objectMapper;
 
     // 출석 상태 변경 이벤트 수신
@@ -31,26 +37,46 @@ public class MeetingAttendanceEventConsumer {
             groupId = "meeting-service"
     )
     public void consumeAttendanceStatusChanged(String message) {
+        String eventId = null;
+        UUID attendanceId = null;
+
         try {
             // Kafka로 수신한 전체 이벤트 JSON 파싱
             JsonNode root = objectMapper.readTree(message);
 
-            // BaseEvent 내부의 payload 필드 추출
+            // 멱등성 기준은 BaseEvent의 eventId를 사용한다.
+            eventId = root.get("eventId").asText();
+
+            // BaseEvent 내부 payload 필드 추출
             JsonNode payload = root.get("payload");
 
-            UUID attendanceId = UUID.fromString(payload.get("attendanceId").asText());
+            attendanceId = UUID.fromString(payload.get("attendanceId").asText());
             UUID meetingId = UUID.fromString(payload.get("meetingId").asText());
             UUID userId = UUID.fromString(payload.get("userId").asText());
             UUID changedBy = UUID.fromString(payload.get("changedBy").asText());
             AttendanceStatus status = AttendanceStatus.valueOf(payload.get("status").asText());
 
             log.info(
-                    "출석 상태 변경 이벤트 수신: attendanceId={}, meetingId={}, userId={}, status={}",
+                    "출석 상태 변경 이벤트 수신: eventId={}, attendanceId={}, meetingId={}, userId={}, status={}",
+                    eventId,
                     attendanceId,
                     meetingId,
                     userId,
                     status
             );
+
+            // 이벤트 처리 전 processed_event를 먼저 저장한다.
+            // 저장 성공한 Consumer만 이후 패널티 누적을 수행한다.
+            boolean acquired = trySaveProcessedEvent(eventId, attendanceId);
+            if (!acquired) {
+                log.info(
+                        "이미 처리 중이거나 처리 완료된 출석 이벤트 skip: consumerName={}, eventId={}, attendanceId={}",
+                        CONSUMER_NAME,
+                        eventId,
+                        attendanceId
+                );
+                return;
+            }
 
             // 이벤트 payload의 meetingId, userId 기준으로 모임원을 조회한다.
             MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(
@@ -62,7 +88,9 @@ public class MeetingAttendanceEventConsumer {
             // 비활성 모임원은 패널티 누적 대상에서 제외한다.
             if (!member.isActive()) {
                 log.warn(
-                        "비활성 모임원 출석 패널티 누적 제외: meetingId={}, userId={}, memberStatus={}",
+                        "비활성 모임원 출석 패널티 누적 제외: eventId={}, attendanceId={}, meetingId={}, userId={}, memberStatus={}",
+                        eventId,
+                        attendanceId,
                         meetingId,
                         userId,
                         member.getStatus()
@@ -71,48 +99,75 @@ public class MeetingAttendanceEventConsumer {
             }
 
             // 패널티 적용 전 현재 카운트 확인
-// 지각 1회에 warningCount가 증가하는지,
-// 아니면 적용 전부터 warningCount가 이미 1이었는지 확인하기 위한 로그
             log.info(
-                    "출석 패널티 적용 전: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
-                    meetingId,
-                    userId,
-                    status,
+                    "출석 패널티 적용 전: eventId={}, attendanceId={}, lateCount={}, absentCount={}, warningCount={}",
+                    eventId,
+                    attendanceId,
                     member.getLateCount(),
                     member.getAbsentCount(),
                     member.getWarningCount()
             );
 
-// 출석 상태에 따라 지각/결석/경고 카운트를 누적한다.
-// 실제 누적 규칙은 MeetingMember 도메인 메서드에 위임한다.
+            // 출석 상태에 따라 지각/결석/경고 카운트를 누적한다.
+            // 실제 누적 규칙은 MeetingMember 도메인 메서드에 위임한다.
             member.applyAttendancePenalty(status, changedBy);
 
-// 패널티 적용 후 카운트 확인
+            // 패널티 적용 후 카운트 확인
             log.info(
-                    "출석 패널티 적용 후: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
-                    meetingId,
-                    userId,
-                    status,
+                    "출석 패널티 적용 후: eventId={}, attendanceId={}, lateCount={}, absentCount={}, warningCount={}, memberStatus={}",
+                    eventId,
+                    attendanceId,
                     member.getLateCount(),
                     member.getAbsentCount(),
-                    member.getWarningCount()
+                    member.getWarningCount(),
+                    member.getStatus()
             );
 
-            log.info(
-                    "출석 패널티 누적 완료: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
-                    meetingId,
-                    userId,
-                    status,
-                    member.getLateCount(),
-                    member.getAbsentCount(),
-                    member.getWarningCount()
+        } catch (BusinessException | IllegalArgumentException e) {
+            // payload 오류, UUID 오류, enum 오류, 모임원 없음 등은 재시도해도 성공하지 않는 비재시도성 오류
+            // 원본 message에는 note 등 사용자 입력값이 포함될 수 있으므로 로그에 남기지 않는다.
+            log.warn(
+                    "출석 이벤트 비재시도성 실패: eventId={}, attendanceId={}, reason={}",
+                    eventId,
+                    attendanceId,
+                    e.getMessage(),
+                    e
             );
 
         } catch (Exception e) {
-            // 이벤트 처리 중 예외가 발생하면 로그를 남기고 예외를 다시 던진다.
-            // 그래야 Kafka listener가 실패 이벤트로 인식할 수 있다.
-            log.error("출석 상태 변경 이벤트 처리 실패: message={}", message, e);
+            // DB 일시 장애 등 예측 불가 오류는 재시도 대상
+            // 원본 message 전체는 개인정보/메모 노출 위험이 있으므로 로그에 남기지 않는다.
+            log.error(
+                    "출석 상태 변경 이벤트 처리 실패: eventId={}, attendanceId={}",
+                    eventId,
+                    attendanceId,
+                    e
+            );
             throw new IllegalStateException("출석 상태 변경 이벤트 처리 실패", e);
+        }
+    }
+
+    // 이벤트 처리 선점 저장
+    // consumer_name + event_id 유니크 제약을 이용해 중복 이벤트 처리를 방지한다.
+    private boolean trySaveProcessedEvent(String eventId, UUID attendanceId) {
+        try {
+            processedEventRepository.saveAndFlush(
+                    ProcessedEvent.of(CONSUMER_NAME, eventId)
+            );
+
+            log.info(
+                    "출석 이벤트 처리 선점 성공: consumerName={}, eventId={}, attendanceId={}",
+                    CONSUMER_NAME,
+                    eventId,
+                    attendanceId
+            );
+
+            return true;
+
+        } catch (DataIntegrityViolationException e) {
+            // 동일 consumerName + eventId가 이미 저장된 경우
+            // 같은 이벤트가 이미 처리 중이거나 처리 완료된 것으로 보고 skip한다.
+            return false;
         }
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
@@ -70,9 +70,33 @@ public class MeetingAttendanceEventConsumer {
                 return;
             }
 
-            // 출석 상태에 따라 지각/결석/경고 카운트를 누적한다.
-            // 실제 누적 규칙은 MeetingMember 도메인 메서드에 위임한다.
+            // 패널티 적용 전 현재 카운트 확인
+// 지각 1회에 warningCount가 증가하는지,
+// 아니면 적용 전부터 warningCount가 이미 1이었는지 확인하기 위한 로그
+            log.info(
+                    "출석 패널티 적용 전: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
+                    meetingId,
+                    userId,
+                    status,
+                    member.getLateCount(),
+                    member.getAbsentCount(),
+                    member.getWarningCount()
+            );
+
+// 출석 상태에 따라 지각/결석/경고 카운트를 누적한다.
+// 실제 누적 규칙은 MeetingMember 도메인 메서드에 위임한다.
             member.applyAttendancePenalty(status, changedBy);
+
+// 패널티 적용 후 카운트 확인
+            log.info(
+                    "출석 패널티 적용 후: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
+                    meetingId,
+                    userId,
+                    status,
+                    member.getLateCount(),
+                    member.getAbsentCount(),
+                    member.getWarningCount()
+            );
 
             log.info(
                     "출석 패널티 누적 완료: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
@@ -1,10 +1,13 @@
 package com.pagely.meetingservice.meeting.infrastructure.messaging;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pagely.common.exception.BusinessException;
-import com.pagely.meetingservice.meeting.domain.event.MeetingAttendanceStatusChangedEvent;
 import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
+import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -18,60 +21,74 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingAttendanceEventConsumer {
 
     private final MeetingMemberRepository meetingMemberRepository;
+    private final ObjectMapper objectMapper;
 
     // 출석 상태 변경 이벤트 수신
-    // 출석 상태가 변경되면 해당 모임원의 지각/결석/경고 카운트를 누적한다.
+    // Kafka 메시지가 JSON 문자열로 들어오기 때문에 String으로 받은 뒤 payload만 직접 파싱한다.
     @Transactional
     @KafkaListener(
             topics = "meeting.attendance.status-changed",
             groupId = "meeting-service"
     )
-    public void consumeAttendanceStatusChanged(
-            MeetingAttendanceStatusChangedEvent event
-    ) {
-        MeetingAttendanceStatusChangedEvent.Payload payload =
-                (MeetingAttendanceStatusChangedEvent.Payload) event.getPayload();
+    public void consumeAttendanceStatusChanged(String message) {
+        try {
+            // Kafka로 수신한 전체 이벤트 JSON 파싱
+            JsonNode root = objectMapper.readTree(message);
 
-        log.info(
-                "출석 상태 변경 이벤트 수신: attendanceId={}, meetingId={}, userId={}, status={}",
-                payload.attendanceId(),
-                payload.meetingId(),
-                payload.userId(),
-                payload.status()
-        );
+            // BaseEvent 내부의 payload 필드 추출
+            JsonNode payload = root.get("payload");
 
-        // 이벤트 payload의 meetingId, userId 기준으로 모임원을 조회한다.
-        MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(
-                        payload.meetingId(),
-                        payload.userId()
-                )
-                .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.MEETING_MEMBER_NOT_FOUND));
+            UUID attendanceId = UUID.fromString(payload.get("attendanceId").asText());
+            UUID meetingId = UUID.fromString(payload.get("meetingId").asText());
+            UUID userId = UUID.fromString(payload.get("userId").asText());
+            UUID changedBy = UUID.fromString(payload.get("changedBy").asText());
+            AttendanceStatus status = AttendanceStatus.valueOf(payload.get("status").asText());
 
-        // 비활성 모임원은 패널티 누적 대상에서 제외한다.
-        if (!member.isActive()) {
-            log.warn(
-                    "비활성 모임원 출석 패널티 누적 제외: meetingId={}, userId={}, status={}",
-                    payload.meetingId(),
-                    payload.userId(),
-                    member.getStatus()
+            log.info(
+                    "출석 상태 변경 이벤트 수신: attendanceId={}, meetingId={}, userId={}, status={}",
+                    attendanceId,
+                    meetingId,
+                    userId,
+                    status
             );
-            return;
+
+            // 이벤트 payload의 meetingId, userId 기준으로 모임원을 조회한다.
+            MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(
+                            meetingId,
+                            userId
+                    )
+                    .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.MEETING_MEMBER_NOT_FOUND));
+
+            // 비활성 모임원은 패널티 누적 대상에서 제외한다.
+            if (!member.isActive()) {
+                log.warn(
+                        "비활성 모임원 출석 패널티 누적 제외: meetingId={}, userId={}, memberStatus={}",
+                        meetingId,
+                        userId,
+                        member.getStatus()
+                );
+                return;
+            }
+
+            // 출석 상태에 따라 지각/결석/경고 카운트를 누적한다.
+            // 실제 누적 규칙은 MeetingMember 도메인 메서드에 위임한다.
+            member.applyAttendancePenalty(status, changedBy);
+
+            log.info(
+                    "출석 패널티 누적 완료: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
+                    meetingId,
+                    userId,
+                    status,
+                    member.getLateCount(),
+                    member.getAbsentCount(),
+                    member.getWarningCount()
+            );
+
+        } catch (Exception e) {
+            // 이벤트 처리 중 예외가 발생하면 로그를 남기고 예외를 다시 던진다.
+            // 그래야 Kafka listener가 실패 이벤트로 인식할 수 있다.
+            log.error("출석 상태 변경 이벤트 처리 실패: message={}", message, e);
+            throw new IllegalStateException("출석 상태 변경 이벤트 처리 실패", e);
         }
-
-        // 출석 상태에 따라 지각/결석/경고 카운트를 누적한다.
-        member.applyAttendancePenalty(
-                payload.status(),
-                payload.changedBy()
-        );
-
-        log.info(
-                "출석 패널티 누적 완료: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
-                payload.meetingId(),
-                payload.userId(),
-                payload.status(),
-                member.getLateCount(),
-                member.getAbsentCount(),
-                member.getWarningCount()
-        );
     }
 }

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/messaging/MeetingAttendanceEventConsumer.java
@@ -1,0 +1,77 @@
+package com.pagely.meetingservice.meeting.infrastructure.messaging;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.event.MeetingAttendanceStatusChangedEvent;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingMemberErrorCode;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+// 출석 관련 Kafka 이벤트 Consumer
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MeetingAttendanceEventConsumer {
+
+    private final MeetingMemberRepository meetingMemberRepository;
+
+    // 출석 상태 변경 이벤트 수신
+    // 출석 상태가 변경되면 해당 모임원의 지각/결석/경고 카운트를 누적한다.
+    @Transactional
+    @KafkaListener(
+            topics = "meeting.attendance.status-changed",
+            groupId = "meeting-service"
+    )
+    public void consumeAttendanceStatusChanged(
+            MeetingAttendanceStatusChangedEvent event
+    ) {
+        MeetingAttendanceStatusChangedEvent.Payload payload =
+                (MeetingAttendanceStatusChangedEvent.Payload) event.getPayload();
+
+        log.info(
+                "출석 상태 변경 이벤트 수신: attendanceId={}, meetingId={}, userId={}, status={}",
+                payload.attendanceId(),
+                payload.meetingId(),
+                payload.userId(),
+                payload.status()
+        );
+
+        // 이벤트 payload의 meetingId, userId 기준으로 모임원을 조회한다.
+        MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(
+                        payload.meetingId(),
+                        payload.userId()
+                )
+                .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.MEETING_MEMBER_NOT_FOUND));
+
+        // 비활성 모임원은 패널티 누적 대상에서 제외한다.
+        if (!member.isActive()) {
+            log.warn(
+                    "비활성 모임원 출석 패널티 누적 제외: meetingId={}, userId={}, status={}",
+                    payload.meetingId(),
+                    payload.userId(),
+                    member.getStatus()
+            );
+            return;
+        }
+
+        // 출석 상태에 따라 지각/결석/경고 카운트를 누적한다.
+        member.applyAttendancePenalty(
+                payload.status(),
+                payload.changedBy()
+        );
+
+        log.info(
+                "출석 패널티 누적 완료: meetingId={}, userId={}, status={}, lateCount={}, absentCount={}, warningCount={}",
+                payload.meetingId(),
+                payload.userId(),
+                payload.status(),
+                member.getLateCount(),
+                member.getAbsentCount(),
+                member.getWarningCount()
+        );
+    }
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaProcessedEventRepository.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/infrastructure/persistence/JpaProcessedEventRepository.java
@@ -1,0 +1,22 @@
+package com.pagely.meetingservice.meeting.infrastructure.persistence;
+
+import com.pagely.meetingservice.meeting.domain.model.ProcessedEvent;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// ProcessedEvent 전용 JPA Repository
+public interface JpaProcessedEventRepository extends JpaRepository<ProcessedEvent, UUID> {
+
+    // Consumer 이름과 BaseEvent eventId 기준으로 기존 처리 여부 조회
+    Optional<ProcessedEvent> findByConsumerNameAndEventId(
+            String consumerName,
+            String eventId
+    );
+
+    // 중복 처리 여부 확인
+    boolean existsByConsumerNameAndEventId(
+            String consumerName,
+            String eventId
+    );
+}

--- a/src/main/resources/db/migration/V3__processed_event.sql
+++ b/src/main/resources/db/migration/V3__processed_event.sql
@@ -1,0 +1,23 @@
+-- =========================
+-- TABLE: p_processed_event
+-- =========================
+CREATE TABLE p_processed_event
+(
+    id            UUID PRIMARY KEY,
+    consumer_name VARCHAR(100) NOT NULL,
+    event_id      VARCHAR(100) NOT NULL,
+    processed_at  TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+-- =========================
+-- UNIQUE CONSTRAINT
+-- =========================
+ALTER TABLE p_processed_event
+    ADD CONSTRAINT uk_p_processed_event_consumer_event UNIQUE (consumer_name, event_id);
+
+-- =========================
+-- INDEX
+-- =========================
+CREATE INDEX idx_p_processed_event_consumer_name ON p_processed_event (consumer_name);
+CREATE INDEX idx_p_processed_event_event_id ON p_processed_event (event_id);
+CREATE INDEX idx_p_processed_event_processed_at ON p_processed_event (processed_at);

--- a/src/test/java/com/pagely/meetingservice/MeetingserviceApplicationTests.java
+++ b/src/test/java/com/pagely/meetingservice/MeetingserviceApplicationTests.java
@@ -2,12 +2,13 @@ package com.pagely.meetingservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class MeetingserviceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+    }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,9 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    listener:
+      auto-startup: false
+
+eureka:
+  client:
+    enabled: false


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
\
- 출석 상태 변경 시 모임원 패널티 누적 로직을 CommandService에서 제거하고 Kafka 이벤트 기반으로 분리
- MeetingAttendanceEventConsumer를 통해 이벤트 수신 후 패널티 누적 처리하도록 구조 개선
- Consumer에서 JSON 문자열 기반 이벤트 파싱 로직 적용 (역직렬화 오류 해결)
- 패널티 적용 전/후 로깅 추가로 디버깅 및 추적 가능하도록 개선
- MeetingMember.applyAttendancePenalty() 정책 수정
  - 지각 1회 → lateCount만 증가
  - 지각 3회 → warningCount +1
  - 결석 1회 → warningCount +1
  - warningCount 3회 이상 → EXPELLED 처리
- null 상태 입력 시 예외 발생하도록 도메인 로직 개선
- MeetingMemberErrorCode에 INVALID_ATTENDANCE_STATUS 추가

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #59 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #59  

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

### Kafka-UI

<img width="1514" height="981" alt="스크린샷 2026-05-01 오전 2 16 17" src="https://github.com/user-attachments/assets/cc4d00bc-61ab-49d9-93c4-0e0f83377f29" />
<img width="1518" height="772" alt="스크린샷 2026-05-01 오전 2 16 39" src="https://github.com/user-attachments/assets/1d4e7bd0-f488-4bfb-a90d-bacfa60aa52e" />


### 지각 누적
<img width="1277" height="517" alt="스크린샷 2026-05-01 오전 1 52 47" src="https://github.com/user-attachments/assets/e1312dae-7d9d-434e-b673-39178e8e1cf2" />

### 지각 1회
<img width="1042" height="305" alt="스크린샷 2026-05-01 오전 2 02 17" src="https://github.com/user-attachments/assets/9ab83c50-d3f8-496a-88ab-bf8447c8d7ae" />

### 지각 2회
<img width="1047" height="297" alt="스크린샷 2026-05-01 오전 2 02 55" src="https://github.com/user-attachments/assets/d9d45d5a-7a92-4182-bba0-108709bf76a9" />

### 지각 3회 -> 경고 1회 추가
<img width="1042" height="324" alt="스크린샷 2026-05-01 오전 2 03 20" src="https://github.com/user-attachments/assets/54aa987d-f77c-41c2-b60a-5fd32dd914b1" />

### 결석 누적
<img width="1266" height="528" alt="스크린샷 2026-05-01 오전 2 10 50" src="https://github.com/user-attachments/assets/8e4b9060-74b5-470a-9e9e-7fbcfdeb2e74" />

### 결석 1회 -> 경고 1회 추가
<img width="1052" height="307" alt="스크린샷 2026-05-01 오전 2 11 02" src="https://github.com/user-attachments/assets/2046f97b-21fb-4a5e-86cb-840afd792300" />



## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 출석 상태 변경 이벤트에 변경자 정보(changedBy)를 포함해 추적합니다.
  * 메시지 기반 소비자와 처리 이력 저장을 도입하여 페널티 적용을 비동기화하고 중복 처리를 방지합니다.
  * 처리 이력 테이블을 위한 DB 마이그레이션을 추가했습니다.

* **Bug Fixes**
  * 지각·결석 페널티 산정 규칙을 조정하고 누적 경고 임계(경고 3회 시 제명)를 명확히 했습니다.
  * 유효하지 않은 출석 상태에 대한 BAD_REQUEST 오류 코드를 추가했습니다.

* **Tests**
  * 테스트 프로파일과 테스트 전용 설정을 추가했습니다.

* **Chores**
  * 라이브러리 의존성 버전을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->