### PR TITLE
Refactor/71 모임 API 성공 응답을 ApiResponse로 통일

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/presentation/controller/MeetingController.java
@@ -4,6 +4,7 @@ import com.pagely.common.auth.annotation.AuthRequired;
 import com.pagely.common.auth.annotation.CurrentUserId;
 import com.pagely.common.pagination.PageRequest;
 import com.pagely.common.pagination.PageResponse;
+import com.pagely.common.response.ApiResponse;
 import com.pagely.meetingservice.meeting.application.dto.command.CreateMeetingScheduleCommand;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateAttendanceStatusCommand;
 import com.pagely.meetingservice.meeting.application.dto.command.UpdateScheduleStatusCommand;
@@ -37,7 +38,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -65,7 +65,7 @@ public class MeetingController {
     // 모임 생성
     @AuthRequired
     @PostMapping
-    public ResponseEntity<MeetingResponse> createMeeting(
+    public ResponseEntity<ApiResponse> createMeeting(
             @CurrentUserId UUID currentUserId,
             @Valid @RequestBody CreateMeetingRequest req
     ) {
@@ -73,31 +73,30 @@ public class MeetingController {
                 req.toCommand(currentUserId)
         );
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(MeetingResponse.from(result));
+        return ApiResponse.created(MeetingResponse.from(result));
     }
 
     // 모임 전체 조회
     @GetMapping
-    public PageResponse<MeetingSummaryResponse> getMeetings(PageRequest pageRequest) {
+    public ResponseEntity<ApiResponse> getMeetings(PageRequest pageRequest) {
         Page<MeetingSummaryResult> results = meetingQueryService.getMeetings(
                 pageRequest.toPageable()
         );
 
-        return PageResponse.of(results, MeetingSummaryResponse::from);
+        return ApiResponse.ok(results, MeetingSummaryResponse::from);
     }
 
     // 모임 상세 조회
     @GetMapping("/{meetingId}")
-    public MeetingResponse getMeeting(@PathVariable UUID meetingId) {
+    public ResponseEntity<ApiResponse> getMeeting(@PathVariable UUID meetingId) {
         MeetingResult result = meetingQueryService.getMeeting(meetingId);
-        return MeetingResponse.from(result);
+        return ApiResponse.ok(MeetingResponse.from(result));
     }
 
     // 모임 가입 신청
     @AuthRequired
     @PostMapping("/{meetingId}/join")
-    public ResponseEntity<MeetingJoinResponse> joinMeeting(
+    public ResponseEntity<ApiResponse> joinMeeting(
             @PathVariable UUID meetingId,
             @CurrentUserId UUID currentUserId,
             @Valid @RequestBody JoinMeetingRequest req
@@ -106,14 +105,13 @@ public class MeetingController {
                 req.toCommand(meetingId, currentUserId)
         );
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(MeetingJoinResponse.from(result));
+        return ApiResponse.created(MeetingJoinResponse.from(result));
     }
 
     // 가입 신청 목록 조회
     @AuthRequired
     @GetMapping("/{meetingId}/join")
-    public PageResponse<MeetingJoinResponse> getMeetingJoinList(
+    public ResponseEntity<ApiResponse> getMeetingJoinList(
             @PathVariable UUID meetingId,
             @CurrentUserId UUID currentUserId,
             @RequestParam(required = false) MeetingJoinStatus joinStatus,
@@ -126,13 +124,13 @@ public class MeetingController {
                 pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"))
         );
 
-        return PageResponse.of(results, MeetingJoinResponse::from);
+        return ApiResponse.ok(results, MeetingJoinResponse::from);
     }
 
     // 모임 가입 승인
     @AuthRequired
     @PostMapping("/{meetingId}/join/{joinId}/approve")
-    public MeetingJoinResponse approveMeetingJoin(
+    public ResponseEntity<ApiResponse> approveMeetingJoin(
             @PathVariable UUID meetingId,
             @PathVariable UUID joinId,
             @CurrentUserId UUID currentUserId
@@ -143,13 +141,13 @@ public class MeetingController {
                 currentUserId
         );
 
-        return MeetingJoinResponse.from(result);
+        return ApiResponse.ok(MeetingJoinResponse.from(result));
     }
 
     // 모임 일정 생성
     @AuthRequired
     @PostMapping("/{meetingId}/schedules")
-    public ResponseEntity<MeetingScheduleResponse> createMeetingSchedule(
+    public ResponseEntity<ApiResponse> createMeetingSchedule(
             @PathVariable UUID meetingId,
             @CurrentUserId UUID currentUserId,
             @Valid @RequestBody CreateMeetingScheduleRequest req
@@ -164,14 +162,13 @@ public class MeetingController {
 
         MeetingScheduleResult result = meetingScheduleCommandService.createSchedule(command);
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(MeetingScheduleResponse.from(result));
+        return ApiResponse.created(MeetingScheduleResponse.from(result));
     }
 
     // 모임 일정 목록 조회
     @AuthRequired
     @GetMapping("/{meetingId}/schedules")
-    public PageResponse<MeetingScheduleResponse> getMeetingSchedules(
+    public ResponseEntity<ApiResponse> getMeetingSchedules(
             @PathVariable UUID meetingId,
             @CurrentUserId UUID currentUserId,
             PageRequest pageRequest
@@ -181,25 +178,25 @@ public class MeetingController {
                 pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "scheduleNumber"))
         );
 
-        return PageResponse.of(results, MeetingScheduleResponse::from);
+        return ApiResponse.ok(results, MeetingScheduleResponse::from);
     }
 
     // 모임 일정 상세 조회
     @AuthRequired
     @GetMapping("/{meetingId}/schedules/{scheduleId}")
-    public MeetingScheduleResponse getMeetingSchedule(
+    public ResponseEntity<ApiResponse> getMeetingSchedule(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
             @CurrentUserId UUID currentUserId
     ) {
         MeetingScheduleResult result = meetingScheduleQueryService.getSchedule(meetingId, scheduleId);
-        return MeetingScheduleResponse.from(result);
+        return ApiResponse.ok(MeetingScheduleResponse.from(result));
     }
 
     // 모임 일정 참석 등록
     @AuthRequired
     @PostMapping("/{meetingId}/schedules/{scheduleId}/join")
-    public ResponseEntity<MeetingAttendanceResponse> joinMeetingSchedule(
+    public ResponseEntity<ApiResponse> joinMeetingSchedule(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
             @CurrentUserId UUID currentUserId
@@ -210,14 +207,13 @@ public class MeetingController {
                 currentUserId
         );
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(MeetingAttendanceResponse.from(result));
+        return ApiResponse.created(MeetingAttendanceResponse.from(result));
     }
 
     // 모임 일정 상태 변경
     @AuthRequired
     @PatchMapping("/{meetingId}/schedules/{scheduleId}/status")
-    public ResponseEntity<MeetingScheduleResponse> changeMeetingScheduleStatus(
+    public ResponseEntity<ApiResponse> changeMeetingScheduleStatus(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
             @CurrentUserId UUID currentUserId,
@@ -231,13 +227,13 @@ public class MeetingController {
 
         MeetingScheduleResult result = meetingScheduleCommandService.changeScheduleStatus(command);
 
-        return ResponseEntity.ok(MeetingScheduleResponse.from(result));
+        return ApiResponse.ok(MeetingScheduleResponse.from(result));
     }
 
     // 특정 일정 출석부 조회
     @AuthRequired
     @GetMapping("/{meetingId}/schedules/{scheduleId}/attendances")
-    public MeetingAttendancePageResponse getScheduleAttendances(
+    public ResponseEntity<ApiResponse> getScheduleAttendances(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
             @CurrentUserId UUID currentUserId,
@@ -256,13 +252,13 @@ public class MeetingController {
                 currentUserId
         );
 
-        return MeetingAttendancePageResponse.from(results, statistics);
+        return ApiResponse.ok(MeetingAttendancePageResponse.from(results, statistics));
     }
 
     // 내 출석부 조회
     @AuthRequired
     @GetMapping("/{meetingId}/attendances/me")
-    public MeetingAttendancePageResponse getMyAttendances(
+    public ResponseEntity<ApiResponse> getMyAttendances(
             @PathVariable UUID meetingId,
             @CurrentUserId UUID currentUserId,
             PageRequest pageRequest
@@ -278,13 +274,13 @@ public class MeetingController {
                 currentUserId
         );
 
-        return MeetingAttendancePageResponse.from(results, statistics);
+        return ApiResponse.ok(MeetingAttendancePageResponse.from(results, statistics));
     }
 
     // 출석 상태 변경
     @AuthRequired
     @PatchMapping("/{meetingId}/schedules/{scheduleId}/attendances")
-    public ResponseEntity<MeetingAttendanceResponse> changeAttendanceStatus(
+    public ResponseEntity<ApiResponse> changeAttendanceStatus(
             @PathVariable UUID meetingId,
             @PathVariable UUID scheduleId,
             @CurrentUserId UUID currentUserId,
@@ -298,6 +294,6 @@ public class MeetingController {
 
         MeetingAttendanceResult result = meetingAttendanceCommandService.changeAttendanceStatus(command);
 
-        return ResponseEntity.ok(MeetingAttendanceResponse.from(result));
+        return ApiResponse.ok(MeetingAttendanceResponse.from(result));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- `MeetingController`의 모든 엔드포인트가 `ResponseEntity<ApiResponse>`를 반환하도록 변경

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #71   \

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="435" height="81" alt="image" src="https://github.com/user-attachments/assets/1aabba0e-fbcb-41d2-9905-00680a10b53f" />
<img width="873" height="365" alt="image" src="https://github.com/user-attachments/assets/d7b07b11-81e9-4a6b-a321-224906a69035" />



## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * REST API 응답 형식이 표준화되었습니다. 미팅 생성, 조회, 참석, 스케줄 관리, 출석 현황 변경 등 모든 엔드포인트에서 일관되고 예측 가능한 응답 구조를 제공하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->