### PR TITLE
Refactor/77 meeting policy refactor

### DIFF
--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingAttendanceCommandService.java
@@ -14,6 +14,7 @@ import com.pagely.meetingservice.meeting.domain.model.AttendanceStatus;
 import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
 import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.policy.MeetingAttendancePolicy;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingAttendanceRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
@@ -49,24 +50,18 @@ public class MeetingAttendanceCommandService {
 
         // 일정이 요청한 모임에 속한 일정인지 검증
         // 다른 모임의 scheduleId로 접근하는 것을 방지
-        if (!schedule.getMeetingId().equals(meetingId)) {
-            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
-        }
+        MeetingAttendancePolicy.validateScheduleBelongsToMeeting(schedule, meetingId);
 
         // 일정 참석은 해당 모임에 가입된 사용자만 가능
         MeetingMember member = meetingMemberRepository.findByMeetingIdAndUserId(meetingId, userId)
                 .orElseThrow(() -> new BusinessException(MeetingAttendanceErrorCode.ONLY_MEMBER_CAN_JOIN_SCHEDULE));
 
         // 탈퇴/강퇴/비활성 상태의 모임원은 일정 참석 불가
-        if (!member.isActive()) {
-            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ACTIVE_MEMBER_CAN_JOIN_SCHEDULE);
-        }
+        MeetingAttendancePolicy.validateActiveMemberForScheduleJoin(member);
 
         // 동일 사용자가 같은 일정에 중복 참석 등록하는 것을 방지
         boolean alreadyJoined = meetingAttendanceRepository.existsByScheduleIdAndUserId(scheduleId, userId);
-        if (alreadyJoined) {
-            throw new BusinessException(MeetingAttendanceErrorCode.ATTENDANCE_ALREADY_EXISTS);
-        }
+        MeetingAttendancePolicy.validateNoDuplicateAttendance(alreadyJoined);
 
         LocalDateTime now = LocalDateTime.now();
 
@@ -107,14 +102,10 @@ public class MeetingAttendanceCommandService {
                 .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
         // 일정이 해당 모임에 속해 있는지 검증
-        if (!schedule.getMeetingId().equals(command.meetingId())) {
-            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
-        }
+        MeetingAttendancePolicy.validateScheduleBelongsToMeeting(schedule, command.meetingId());
 
         // 출석 상태 변경은 진행 중인 일정에서만 가능
-        if (!schedule.isOngoing()) {
-            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ONGOING_SCHEDULE_CAN_CHANGE_ATTENDANCE);
-        }
+        MeetingAttendancePolicy.validateAlreadyOngoing(schedule);
 
         // 출석 상태를 변경하려는 사용자가 해당 모임의 멤버인지 확인
         MeetingMember updater = meetingMemberRepository.findByMeetingIdAndUserId(
@@ -124,9 +115,7 @@ public class MeetingAttendanceCommandService {
                 .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED));
 
         // 출석 상태 변경은 ACTIVE 상태의 모임장만 가능
-        if (!updater.isActive() || !updater.isHost()) {
-            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_HOST_CAN_CHANGE_ATTENDANCE);
-        }
+        MeetingAttendancePolicy.validateHostChangesAttendance(updater);
 
         // 출석 상태 변경 대상자가 해당 모임의 멤버인지 확인
         MeetingMember targetMember = meetingMemberRepository.findByMeetingIdAndUserId(
@@ -137,9 +126,7 @@ public class MeetingAttendanceCommandService {
                         () -> new BusinessException(MeetingAttendanceErrorCode.ATTENDANCE_USER_NOT_MEETING_MEMBER));
 
         // 탈퇴/강퇴/비활성 상태의 모임원은 출석 상태 변경 대상이 될 수 없음
-        if (!targetMember.isActive()) {
-            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ACTIVE_MEMBER_CAN_CHANGE_ATTENDANCE);
-        }
+        MeetingAttendancePolicy.validateAttendanceTargetIsActive(targetMember);
 
         // 변경할 출석 정보 조회
         MeetingAttendance attendance = meetingAttendanceRepository.findByScheduleIdAndUserId(

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingJoinService.java
@@ -11,8 +11,8 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMemberRole;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMemberStatus;
-import com.pagely.meetingservice.meeting.domain.model.MeetingStatus;
 import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
+import com.pagely.meetingservice.meeting.domain.policy.MeetingJoinPolicy;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingJoinRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
@@ -59,9 +59,7 @@ public class MeetingJoinService {
         syncRecruitClosedPeriod(meeting);
 
         // 모임장만 가입 신청 목록을 조회할 수 있음
-        if (!meeting.getHostId().equals(requesterHostId)) {
-            throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_VIEW_JOIN_LIST);
-        }
+        MeetingJoinPolicy.validateHost(meeting, requesterHostId);
 
         // 가입 상태 조건이 있으면 상태별 조회, 없으면 전체 조회
         Page<MeetingJoin> joins = joinStatus != null
@@ -80,11 +78,23 @@ public class MeetingJoinService {
 
         syncRecruitClosedPeriod(meeting);
 
-        validateMeetingChangeableStatus(meeting);
-        validateRecruitStatusForApply(meeting.getRecruitStatus());
-        validateCapacityForApply(command.meetingId(), meeting);
-        validateJoinReapplyPolicy(command.meetingId(), command.recruitUserId());
-        validateBlockedMemberStatus(command.meetingId(), command.recruitUserId());
+        MeetingJoinPolicy.validateMeetingAllowsJoin(meeting);
+        MeetingJoinPolicy.validateRecruitOpenForApply(meeting.getRecruitStatus());
+
+        long activeForApply = meetingMemberRepository.countByMeetingIdAndStatus(
+                command.meetingId(), MeetingMemberStatus.ACTIVE);
+
+        MeetingJoinPolicy.validateCapacityNotFullForApply(activeForApply, meeting.getRecruitMax());
+        MeetingJoin existingJoin = meetingJoinRepository
+                .findByMeetingIdAndRecruitUserId(command.meetingId(), command.recruitUserId())
+                .orElse(null);
+
+        MeetingJoinPolicy.validateReapplyPolicy(existingJoin);
+        MeetingMember existingMember = meetingMemberRepository
+                .findByMeetingIdAndUserId(command.meetingId(), command.recruitUserId())
+                .orElse(null);
+
+        MeetingJoinPolicy.validateMemberAllowsApply(existingMember); // 강퇴 등 차단
 
         UUID joinId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
@@ -103,29 +113,19 @@ public class MeetingJoinService {
 
         syncRecruitClosedPeriod(meeting);
 
-        validateMeetingChangeableStatus(meeting);
-
-        if (!meeting.getHostId().equals(hostId)) { // 모임장 검증
-            throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_APPROVE_JOIN);
-        }
+        MeetingJoinPolicy.validateMeetingAllowsJoin(meeting);
+        MeetingJoinPolicy.validateHostForApprove(meeting, hostId);
 
         MeetingJoin join = meetingJoinRepository.findById(joinId)
                 .orElseThrow(() -> new BusinessException(MeetingJoinErrorCode.MEETING_JOIN_NOT_FOUND));
 
-        if (!join.getMeetingId().equals(meetingId)) {
-            throw new BusinessException(MeetingJoinErrorCode.JOIN_NOT_FOR_MEETING);
-        }
-
-        if (meetingMemberRepository.existsByMeetingIdAndUserId(meetingId,
-                join.getRecruitUserId())) { // 이미 모임에 참여중인 사용자 검증
-            throw new BusinessException(MeetingJoinErrorCode.ALREADY_MEETING_MEMBER);
-        }
+        MeetingJoinPolicy.validateJoinForMeeting(join, meetingId);
+        boolean alreadyMember = meetingMemberRepository.existsByMeetingIdAndUserId(meetingId, join.getRecruitUserId());
+        MeetingJoinPolicy.validateNotAlreadyMember(alreadyMember);
 
         long activeCount = meetingMemberRepository.countByMeetingIdAndStatus(meetingId, MeetingMemberStatus.ACTIVE);
 
-        if (activeCount >= meeting.getRecruitMax()) { // 모임 정원 검증
-            throw new BusinessException(MeetingJoinErrorCode.MEETING_RECRUIT_FULL);
-        }
+        MeetingJoinPolicy.validateCapacityForApprove(activeCount, meeting.getRecruitMax());
 
         join.approve(hostId);
 
@@ -148,63 +148,9 @@ public class MeetingJoinService {
         syncRecruitStatusAfterApprove(meeting, hostId);
 
         meetingRepository.save(meeting);
-        
+
         return MeetingJoinResult.from(savedJoin);
 
-    }
-
-    private void validateMeetingChangeableStatus(Meeting meeting) { // 모임 변경 가능 상태 검증
-        if (meeting.getMeetingStatus() != MeetingStatus.UPCOMING
-                && meeting.getMeetingStatus() != MeetingStatus.IN_PROGRESS) {
-            throw new BusinessException(MeetingErrorCode.INVALID_MEETING_STATUS);
-        }
-    }
-
-    private void validateRecruitStatusForApply(RecruitStatus recruitStatus) { // 가입 신청 가능 모집 상태 검증
-        if (recruitStatus == RecruitStatus.CLOSED) {
-            throw new BusinessException(MeetingJoinErrorCode.NOT_RECRUITING_MEETING);
-        }
-        if (recruitStatus == RecruitStatus.FULL) {
-            throw new BusinessException(MeetingJoinErrorCode.MEETING_RECRUIT_FULL);
-        }
-        if (recruitStatus != RecruitStatus.RECRUITING) {
-            throw new BusinessException(MeetingJoinErrorCode.NOT_RECRUITING_MEETING);
-        }
-    }
-
-    private void validateJoinReapplyPolicy(UUID meetingId, UUID recruitUserId) { // 기존 신청 이력을 기준으로 재신청 검증
-        MeetingJoin existingJoin = meetingJoinRepository.findByMeetingIdAndRecruitUserId(meetingId, recruitUserId)
-                .orElse(null);
-        if (existingJoin == null) {
-            return;
-        }
-        if (existingJoin.getJoinStatus() == MeetingJoinStatus.REJECTED) {
-            throw new BusinessException(MeetingJoinErrorCode.REJECTED_USER_CANNOT_REAPPLY);
-        }
-        if (existingJoin.getJoinStatus() == MeetingJoinStatus.PENDING
-                || existingJoin.getJoinStatus() == MeetingJoinStatus.APPROVED) {
-            throw new BusinessException(MeetingJoinErrorCode.MEETING_JOIN_ALREADY_EXISTS);
-        }
-    }
-
-    private void validateBlockedMemberStatus(UUID meetingId, UUID recruitUserId) { // 멤버 상태 기반 신청 차단
-        MeetingMember existingMember = meetingMemberRepository.findByMeetingIdAndUserId(meetingId, recruitUserId)
-                .orElse(null);
-        if (existingMember == null) {
-            return;
-        }
-        if (existingMember.getStatus() == MeetingMemberStatus.REMOVED
-                || existingMember.getStatus() == MeetingMemberStatus.EXPELLED) {
-            throw new BusinessException(MeetingJoinErrorCode.REJECTED_USER_CANNOT_REAPPLY);
-        }
-    }
-
-    private void validateCapacityForApply(UUID meetingId, Meeting meeting){
-        long activeCount = meetingMemberRepository.countByMeetingIdAndStatus(meetingId, MeetingMemberStatus.ACTIVE);
-
-        if(activeCount >= meeting.getRecruitMax()){
-            throw new BusinessException(MeetingJoinErrorCode.MEETING_RECRUIT_FULL);
-        }
     }
 
     private void syncRecruitStatusAfterApprove(Meeting meeting, UUID updaterId) { // 승인 이후 모집 상태 동기화

--- a/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleCommandService.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/application/service/MeetingScheduleCommandService.java
@@ -18,6 +18,7 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingAttendance;
 import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
 import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
 import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+import com.pagely.meetingservice.meeting.domain.policy.MeetingSchedulePolicy;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingAttendanceRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingMemberRepository;
 import com.pagely.meetingservice.meeting.domain.repository.MeetingRepository;
@@ -50,11 +51,7 @@ public class MeetingScheduleCommandService {
         Meeting meeting = meetingRepository.findByIdForUpdate(command.meetingId())
                 .orElseThrow(() -> new BusinessException(MeetingErrorCode.MEETING_NOT_FOUND));
 
-        if (meeting.isOneTime()) {
-            throw new BusinessException(
-                    MeetingScheduleErrorCode.ONE_TIME_MEETING_CANNOT_CREATE_ADDITIONAL_SCHEDULE
-            );
-        }
+        MeetingSchedulePolicy.validateAdditionalScheduleAllowed(meeting);
 
         MeetingMember requester = meetingMemberRepository.findByMeetingIdAndUserId(
                         command.meetingId(),
@@ -62,9 +59,7 @@ public class MeetingScheduleCommandService {
                 )
                 .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED));
 
-        if (!requester.isActive() || !requester.isHost()) {
-            throw new BusinessException(MeetingScheduleErrorCode.ONLY_HOST_CAN_CREATE_SCHEDULE);
-        }
+        MeetingSchedulePolicy.validateHostCreateSchedule(requester);
 
         bookProvider.validateBook(command.bookId());
 
@@ -103,14 +98,9 @@ public class MeetingScheduleCommandService {
         MeetingSchedule schedule = meetingScheduleRepository.findByIdForUpdate(command.scheduleId())
                 .orElseThrow(() -> new BusinessException(MeetingScheduleErrorCode.MEETING_SCHEDULE_NOT_FOUND));
 
-        if (!schedule.getMeetingId().equals(command.meetingId())) {
-            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
-        }
+        MeetingSchedulePolicy.validateScheduleBelongsToMeeting(schedule, command.meetingId());
 
-        if (schedule.getStatus() == MeetingScheduleStatus.ONGOING
-                && command.status() == MeetingScheduleStatus.ONGOING) {
-            throw new BusinessException(MeetingScheduleErrorCode.INVALID_SCHEDULE_STATUS_CHANGE);
-        }
+        MeetingSchedulePolicy.validateAlreadyOngoing(schedule, command.status());
 
         MeetingMember updater = meetingMemberRepository.findByMeetingIdAndUserId(
                         command.meetingId(),
@@ -118,9 +108,7 @@ public class MeetingScheduleCommandService {
                 )
                 .orElseThrow(() -> new BusinessException(MeetingMemberErrorCode.ONLY_MEETING_MEMBER_ALLOWED));
 
-        if (!updater.isActive() || !updater.isHost()) {
-            throw new BusinessException(MeetingScheduleErrorCode.ONLY_HOST_CAN_CHANGE_SCHEDULE_STATUS);
-        }
+        MeetingSchedulePolicy.validateHostChangesScheduleStatus(updater);
 
         List<MeetingAttendance> autoAbsentAttendances = List.of();
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingAttendancePolicy.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingAttendancePolicy.java
@@ -1,0 +1,52 @@
+package com.pagely.meetingservice.meeting.domain.policy;
+
+import java.util.UUID;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingAttendanceErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+
+public final class MeetingAttendancePolicy {
+
+    private MeetingAttendancePolicy() {
+    }
+
+    public static void validateScheduleBelongsToMeeting(MeetingSchedule schedule, UUID meetingId) {
+        if (!schedule.getMeetingId().equals(meetingId)) {
+            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
+        }
+    }
+
+    public static void validateActiveMemberForScheduleJoin(MeetingMember member) {
+        if (!member.isActive()) {
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ACTIVE_MEMBER_CAN_JOIN_SCHEDULE);
+        }
+    }
+
+    public static void validateNoDuplicateAttendance(boolean alreadyJoined) {
+        if (alreadyJoined) {
+            throw new BusinessException(MeetingAttendanceErrorCode.ATTENDANCE_ALREADY_EXISTS);
+        }
+    }
+
+    public static void validateAlreadyOngoing(MeetingSchedule schedule) {
+        if (!schedule.isOngoing()) {
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ONGOING_SCHEDULE_CAN_CHANGE_ATTENDANCE);
+        }
+    }
+
+    public static void validateHostChangesAttendance(MeetingMember updater) {
+        if (!updater.isActive() || !updater.isHost()) {
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_HOST_CAN_CHANGE_ATTENDANCE);
+        }
+    }
+
+    public static void validateAttendanceTargetIsActive(MeetingMember target) {
+        if (!target.isActive()) {
+            throw new BusinessException(MeetingAttendanceErrorCode.ONLY_ACTIVE_MEMBER_CAN_CHANGE_ATTENDANCE);
+        }
+    }
+
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingJoinPolicy.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingJoinPolicy.java
@@ -13,7 +13,7 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingMemberStatus;
 import com.pagely.meetingservice.meeting.domain.model.MeetingStatus;
 import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
 
-public class MeetingJoinPolicy {
+public final class MeetingJoinPolicy {
     
     private MeetingJoinPolicy(){}
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingJoinPolicy.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingJoinPolicy.java
@@ -1,0 +1,106 @@
+package com.pagely.meetingservice.meeting.domain.policy;
+
+import java.util.UUID;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingErrorCode;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingJoinErrorCode;
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.model.MeetingJoin;
+import com.pagely.meetingservice.meeting.domain.model.MeetingJoinStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMemberStatus;
+import com.pagely.meetingservice.meeting.domain.model.MeetingStatus;
+import com.pagely.meetingservice.meeting.domain.model.RecruitStatus;
+
+public class MeetingJoinPolicy {
+    
+    private MeetingJoinPolicy(){}
+
+    // 모임 진행 상태 변경 가능 검증
+    public static void validateMeetingAllowsJoin(Meeting meeting){
+        if(meeting.getMeetingStatus()!=MeetingStatus.UPCOMING &&
+    meeting.getMeetingStatus() != MeetingStatus.IN_PROGRESS){
+        throw new BusinessException(MeetingErrorCode.INVALID_MEETING_STATUS);
+    }
+    }
+
+    // 모집 상태 RECRUITING 인지 검증
+    public static void validateRecruitOpenForApply(RecruitStatus recruitStatus){
+        if(recruitStatus==RecruitStatus.CLOSED){
+            throw new BusinessException(MeetingJoinErrorCode.NOT_RECRUITING_MEETING);
+        }
+        if(recruitStatus==RecruitStatus.FULL){
+            throw new BusinessException(MeetingJoinErrorCode.MEETING_RECRUIT_FULL);
+        }
+        if(recruitStatus!=RecruitStatus.RECRUITING){
+            throw new BusinessException(MeetingJoinErrorCode.NOT_RECRUITING_MEETING);
+        }
+    }
+
+    // 정원 여유가 있는지 검사(신청 시점 기준 ACTIVE 상태 멤버 수)
+    public static void validateCapacityNotFullForApply(long activeCount, int recruitMax){
+        if(activeCount >= recruitMax){
+            throw new BusinessException(MeetingJoinErrorCode.MEETING_RECRUIT_FULL);
+        }
+    }
+
+    // 목록 조회 요청자가 모임장인지 체크
+    public static void validateHost(Meeting meeting, UUID requestId){
+        if(!meeting.getHostId().equals(requestId)){
+            throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_VIEW_JOIN_LIST);
+        }
+    }
+
+    // 승인 요청자가 모임장인지 검사
+    public static void validateHostForApprove(Meeting meeting, UUID hostId){
+        if(!meeting.getHostId().equals(hostId)){
+            throw new BusinessException(MeetingJoinErrorCode.ONLY_HOST_CAN_APPROVE_JOIN);
+        }
+    }
+
+    // 기존 신청 이력을 기준으로 재신청 가능 여부 검사
+    public static void validateReapplyPolicy(MeetingJoin join){
+        if(join == null){
+            return;
+        }
+        if(join.getJoinStatus()==MeetingJoinStatus.REJECTED){
+            throw new BusinessException(MeetingJoinErrorCode.REJECTED_USER_CANNOT_REAPPLY);
+        }
+        if(join.getJoinStatus()==MeetingJoinStatus.PENDING || join.getJoinStatus()==MeetingJoinStatus.APPROVED){
+            throw new BusinessException(MeetingJoinErrorCode.MEETING_JOIN_ALREADY_EXISTS);
+        }
+    }
+
+    // REMOVED, EXPELLED 상태 멤버 신청 차단
+    public static void validateMemberAllowsApply(MeetingMember member){
+        if(member==null){
+            return;
+        }
+        if(member.getStatus()==MeetingMemberStatus.REMOVED || member.getStatus()==MeetingMemberStatus.EXPELLED){
+            throw new BusinessException(MeetingJoinErrorCode.REJECTED_USER_CANNOT_REAPPLY);
+        }
+    }
+
+    // 가입 신청이 모임에 속하는지 검사
+    public static void validateJoinForMeeting(MeetingJoin join, UUID meetingId){
+        if(!join.getMeetingId().equals(meetingId)){
+            throw new BusinessException(MeetingJoinErrorCode.JOIN_NOT_FOR_MEETING);
+        }
+    }
+
+    // 이미 모임에 참여중인 사용자인지 검사
+    public static void validateNotAlreadyMember(boolean alreadyMember){
+        if(alreadyMember){
+            throw new BusinessException(MeetingJoinErrorCode.ALREADY_MEETING_MEMBER);
+        }
+    }
+
+    // 정원 초과 여부 검사
+    public static void validateCapacityForApprove(long activeMemberCount, int recruitMax){
+        if(activeMemberCount >= recruitMax){
+            throw new BusinessException(MeetingJoinErrorCode.MEETING_RECRUIT_FULL);
+        }
+    }
+
+}

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingSchedulePolicy.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingSchedulePolicy.java
@@ -9,7 +9,7 @@ import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
 import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
 import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
 
-public class MeetingSchedulePolicy {
+public final class MeetingSchedulePolicy {
     private MeetingSchedulePolicy() {
     }
 

--- a/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingSchedulePolicy.java
+++ b/src/main/java/com/pagely/meetingservice/meeting/domain/policy/MeetingSchedulePolicy.java
@@ -1,0 +1,52 @@
+package com.pagely.meetingservice.meeting.domain.policy;
+
+import java.util.UUID;
+
+import com.pagely.common.exception.BusinessException;
+import com.pagely.meetingservice.meeting.domain.exception.MeetingScheduleErrorCode;
+import com.pagely.meetingservice.meeting.domain.model.Meeting;
+import com.pagely.meetingservice.meeting.domain.model.MeetingMember;
+import com.pagely.meetingservice.meeting.domain.model.MeetingSchedule;
+import com.pagely.meetingservice.meeting.domain.model.MeetingScheduleStatus;
+
+public class MeetingSchedulePolicy {
+    private MeetingSchedulePolicy() {
+    }
+
+    // 정기 외 일정 추가 가능 여부
+    public static void validateAdditionalScheduleAllowed(Meeting meeting) {
+        if (meeting.isOneTime()) {
+            throw new BusinessException(
+                    MeetingScheduleErrorCode.ONE_TIME_MEETING_CANNOT_CREATE_ADDITIONAL_SCHEDULE
+            );
+        }
+    }
+
+    // 일정 생성 권한 검증
+    public static void validateHostCreateSchedule(MeetingMember requester) {
+        if (!requester.isActive() || !requester.isHost()) {
+            throw new BusinessException(MeetingScheduleErrorCode.ONLY_HOST_CAN_CREATE_SCHEDULE);
+        }
+    }
+
+    // 일정이 모임에 속하는지 검사
+    public static void validateScheduleBelongsToMeeting(MeetingSchedule schedule, UUID meetingId) {
+        if (!schedule.getMeetingId().equals(meetingId)) {
+            throw new BusinessException(MeetingScheduleErrorCode.SCHEDULE_NOT_FOR_MEETING);
+        }
+    }
+
+    // ONGOING 중복 전이 방지
+    public static void validateAlreadyOngoing(MeetingSchedule schedule, MeetingScheduleStatus requested) {
+        if (schedule.getStatus() == MeetingScheduleStatus.ONGOING && requested == MeetingScheduleStatus.ONGOING) {
+            throw new BusinessException(MeetingScheduleErrorCode.INVALID_SCHEDULE_STATUS_CHANGE);
+        }
+    }
+
+    // 일정 상태 변경 권한 검사
+    public static void validateHostChangesScheduleStatus(MeetingMember updater) {
+        if (!updater.isActive() || !updater.isHost()) {
+            throw new BusinessException(MeetingScheduleErrorCode.ONLY_HOST_CAN_CHANGE_SCHEDULE_STATUS);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 모임 가입, 일정, 출석 커맨드에 흩어져 있던 검증 로직을 `meeting.domain.policy`로 분리하고, `MeetingJoinService`·`MeetingScheduleCommandService`·`MeetingAttendanceCommandService`에서는 Policy의 `validate*` 호출로 위임


## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #77   \

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1045" height="751" alt="image" src="https://github.com/user-attachments/assets/0de6a67a-2e02-4acb-bf20-808d42f69fa3" />
<img width="1025" height="756" alt="image" src="https://github.com/user-attachments/assets/2e613169-1f84-4f56-9760-073ac6ef6de4" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
- [ ] 다른 모임 유스케이스도 동일 패턴으로 Policy를 확장할지
 (모집 기간 동기화, 승인 후 모집 상태 갱신, 트랜잭션 커밋 이후 Quartz 등록/삭제, 이벤트 발행)
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 회의 참석, 참여, 일정 관련 유효성 검사 로직을 정책 클래스로 중앙화하여 코드 구조를 개선했습니다.
  * 여러 서비스의 비즈니스 규칙 검증을 전담 정책 컴포넌트로 통합하여 유지보수성을 향상시켰습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pagely-wisely/meeting-service/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->