### PR TITLE
Chore/85 로컬용 Compose 스택 및 모니터링 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 .vscode/
 
 src/main/resources/.env
+/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /workspace
+COPY . .
+ARG GPR_USER
+ARG GPR_KEY
+ENV GPR_USER=${GPR_USER}
+ENV GPR_KEY=${GPR_KEY}
+RUN chmod +x gradlew
+RUN ./gradlew bootJar --no-daemon -Pgpr.user="${GPR_USER}" -Pgpr.key="${GPR_KEY}"
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=builder /workspace/build/libs/*.jar app.jar
+EXPOSE 19011
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,85 @@
 services:
+  # ---------------------------------------------------------------------------
+  # meeting-service
+  # ---------------------------------------------------------------------------
+  meetingservice:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        GPR_USER: ${GPR_USER}
+        GPR_KEY: ${GPR_KEY}
+    container_name: pagely-meetingservice
+    ports:
+      - "19011:19011"
+    environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      MEETING_DB_NAME: meetingservice
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      KAFKA_EXTERNAL_HOST: ${KAFKA_EXTERNAL_HOST}
+      KAFKA_EXTERNAL_PORT: ${KAFKA_EXTERNAL_PORT}
+      EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
+      BOOK_SERVICE_URL: ${BOOK_SERVICE_URL}
+      EUREKA_CLIENT_ENABLED: "false"
+      EUREKA_CLIENT_REGISTER_WITH_EUREKA: "false"
+      EUREKA_CLIENT_FETCH_REGISTRY: "false"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      book-service:
+        condition: service_healthy
+  # ---------------------------------------------------------------------------
+  # PostgreSQL
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    container_name: pagely-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: meetingservice
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgre -d meetingservice"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+  # ---------------------------------------------------------------------------
+  # Kafka
+  # ---------------------------------------------------------------------------
+  kafka:
+    image: bitnamilegacy/kafka:3.3.2
+    container_name: pagely-kafka
+    ports:
+      - "9092:9092"
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_CFG_NODE_ID: "0"
+      KAFKA_CFG_PROCESS_ROLES: "controller,broker"
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "0@kafka:9093"
+      KAFKA_KRAFT_CLUSTER_ID: "abcdefghijklmnopqrstuv"
+      KAFKA_CFG_LISTENERS: "PLAINTEXT://:9092,CONTROLLER://:9093"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
+    healthcheck: 
+      test: ["CMD-SHELL", "/opt/bitnami/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 40s
+  # ---------------------------------------------------------------------------
+  # Prometheus
+  # ---------------------------------------------------------------------------
   prometheus:
     image: prom/prometheus:latest
     container_name: pagely-prometheus
@@ -9,17 +90,57 @@ services:
     extra_hosts:
       # Docker 컨테이너에서 로컬 PC의 meeting-service에 접근하기 위한 설정
       - "host.docker.internal:host-gateway"
+    depends_on:
+      meetingservice:
+        condition: service_started
 
+  # ---------------------------------------------------------------------------
+  # Grafana
+  # ---------------------------------------------------------------------------
   grafana:
     image: grafana/grafana:latest
     container_name: pagely-grafana
     ports:
       - "3000:3000"
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_started
+  # ---------------------------------------------------------------------------
+  # Eureka
+  #  eureka:
+  #  image: springcloud/eureka:2.2.7.RELEASE
+  #  container_name: pagely-eureka
+  #  ports:
+  #    - "8761:8761"
+  #  environment:
+  #    JAVA_OPTS: "-Dserver.port=8761"
+  #  healthcheck:
+  #    test: ["CMD-SHELL", "curl -f http://localhost:8761/actuator/health || exit 1"]
+  #    interval: 10s
+  #    timeout: 5s
+ #     retries: 10
+  #    start_period: 60s
+  # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
+  # Zipkin
+  # ---------------------------------------------------------------------------
 
   zipkin:
     image: openzipkin/zipkin:latest
     container_name: pagely-zipkin
     ports:
       - "9411:9411"
+
+  # ---------------------------------------------------------------------------
+  # book-service Feign이 호출하는 book-service 대역
+  # ---------------------------------------------------------------------------
+  book-service:
+    image: wiremock/wiremock:latest
+    container_name: pagely-book-mock
+    ports:
+      - "19051:8080"
+    command:
+      - "--verbose"
+volumes:
+  pgdata:

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -5,5 +5,4 @@ scrape_configs:
   - job_name: 'meetingservice'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      # meeting-service를 IntelliJ/로컬에서 실행하는 경우
-      - targets: [ 'host.docker.internal:19011' ]
+      - targets: [ 'meetingservice:19011' ]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: meetingservice
 
   config:
-    import: optional:classpath:/.env[.properties]
+    import: optional:file:./.env[.properties]
 
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${MEETING_DB_NAME}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

로컬에서 meeting-service와 주변 의존 서비스(DB, Kafka, book-service 등)를 한 번에 띄울 수 있도록 Docker Compose와 앱용 Dockerfile을 추가
Prometheus·Grafana는 Compose 네트워크 기준으로 데이터소스가 잡히도록 정리
선택적 환경 변수는 레포지토리 루트의 `.env`에서 읽도록 함

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #85   \

- `docker-compose.yml`: 로컬 기동용 서비스 정의
- `Dockerfile`: 애플리케이션 이미지 빌드 및 실행
- `monitoring/prometheus.yml`: scrape target을 실행 환경에 맞게 조정
- `monitoring/grafana/`: Prometheus 데이터소스 프로비저닝
- `application.yml`: `spring.config.import`를 `optional:file:./.env[.properties]`로 변경(루트에 compose파일과 같이 두기)
- `.gitignore`: 루트 `/.env` 제외 추가

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] `docker compose up --build`로 기대 서비스 기동 확인 (필요 시 인증샷)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지
- [ ] `.env` 실값·토큰이 커밋에 포함되지 않았는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="1456" height="400" alt="image" src="https://github.com/user-attachments/assets/d7597aac-18e4-427c-88de-113f15e238db" />
<img width="1758" height="324" alt="image" src="https://github.com/user-attachments/assets/2bc820ba-04d9-4e2b-a806-a283a51ec960" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Docker 기반 애플리케이션 배포 환경 추가
  * Prometheus, Grafana, Zipkin을 포함한 모니터링 스택 구성
  * PostgreSQL, Kafka, 외부 서비스 모의 환경과의 다중 서비스 오케스트레이션

* **Chores**
  * 환경 설정 파일 로드 경로 변경

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pagely-wisely/meeting-service/pull/86)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->